### PR TITLE
[FIX]product_configurator_mrp: reconfigure button visible in draft only

### DIFF
--- a/product_configurator_mrp/views/mrp_view.xml
+++ b/product_configurator_mrp/views/mrp_view.xml
@@ -23,7 +23,7 @@
                         class="oe_highlight"
                         type="object"
                         string="Reconfigure"
-                        attrs="{'invisible': [('config_ok','=',False)]}"
+                        attrs="{'invisible': ['|', ('config_ok','=',False), ('state', '!=', 'draft')]}"
                     />
                 </div>
             </xpath>


### PR DESCRIPTION
hide reconfigure button in all states except draft, because odoo allow to change product in manufacturing order only in draft state.