### PR TITLE
[14.0][FIX] product_configurator (Issue#36)

### DIFF
--- a/product_configurator/models/product_config.py
+++ b/product_configurator/models/product_config.py
@@ -1224,13 +1224,25 @@ class ProductConfigSession(models.Model):
             config_lines = product_tmpl.config_line_ids.filtered(
                 lambda l: attr_val_id in l.value_ids.ids
             )
-            domains = config_lines.mapped("domain_id").compute_domain()
-            avail = self.validate_domains_against_sels(domains, value_ids, custom_vals)
-            if avail:
-                avail_val_ids.append(attr_val_id)
-            elif attr_val_id in value_ids:
-                value_ids.remove(attr_val_id)
-
+            if len(config_lines) > 1:
+                for config in config_lines:
+                    domain = config.domain_id.compute_domain()
+                    avalable = self.validate_domains_against_sels(
+                        domain, value_ids, custom_vals
+                    )
+                    if avalable:
+                        avail_val_ids.append(attr_val_id)
+                    elif attr_val_id in value_ids:
+                        value_ids.remove(attr_val_id)
+            else:
+                domains = config_lines.mapped("domain_id").compute_domain()
+                avail = self.validate_domains_against_sels(
+                    domains, value_ids, custom_vals
+                )
+                if avail:
+                    avail_val_ids.append(attr_val_id)
+                elif attr_val_id in value_ids:
+                    value_ids.remove(attr_val_id)
         return avail_val_ids
 
     @api.model


### PR DESCRIPTION
This fix is for issue #36 

If you have multiple restrictions for an attribute and they share attribute values, then the shared value won't show no matter which restriction applies based on the users selection during configuration.

Now the code takes multiple restrictions into account and will properly show all the options related to the restriction that applies.

See the issue for screenshots of the issue, and these screenshots show the fix:
The value 'None' is set on both restrictions so will now show if glass bottle or can is selected for the Container Type:
![image](https://user-images.githubusercontent.com/36892066/121601832-b5dffc80-ca03-11eb-9796-a8c99ab69e00.png)

Glass bottle shows the 'None' cap option.
![image](https://user-images.githubusercontent.com/36892066/121601780-a52f8680-ca03-11eb-9593-3acd296a0c7f.png)


Plastic Bottle shows only the 'Plastic' cap option.
![image](https://user-images.githubusercontent.com/36892066/121601758-9b0d8800-ca03-11eb-94b4-b9741c98b8e1.png)