### PR TITLE
[12.0][MIG] Backport of module product_configurator

### DIFF
--- a/product_configurator/__manifest__.py
+++ b/product_configurator/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Product Configurator",
-    "version": "14.0.1.2.2",
+    "version": "12.0.1.2.2",
     "category": "Generic Modules/Base",
     "summary": "Base for product configuration interface modules",
     "author": "Pledra, Odoo Community Association (OCA)",

--- a/product_configurator/demo/config_image_ids.xml
+++ b/product_configurator/demo/config_image_ids.xml
@@ -8,7 +8,7 @@
         <field name="name">Coupé Red</field>
         <field name="product_tmpl_id" ref="bmw_2_series" />
         <field
-                name="image_1920"
+                name="image"
                 type="base64"
                 file="product_configurator/static/img/2-series-coupe.jpg"
             />
@@ -24,7 +24,7 @@
         <field name="name">Coupé Silver</field>
         <field name="product_tmpl_id" ref="bmw_2_series" />
         <field
-                name="image_1920"
+                name="image"
                 type="base64"
                 file="product_configurator/static/img/2-series-coupe-silver.jpg"
             />
@@ -40,7 +40,7 @@
         <field name="name">Coupé Black</field>
         <field name="product_tmpl_id" ref="bmw_2_series" />
         <field
-                name="image_1920"
+                name="image"
                 type="base64"
                 file="product_configurator/static/img/2-series-coupe-black.jpg"
             />
@@ -56,7 +56,7 @@
         <field name="name">Coupé Red Rims 384</field>
         <field name="product_tmpl_id" ref="bmw_2_series" />
         <field
-                name="image_1920"
+                name="image"
                 type="base64"
                 file="product_configurator/static/img/2-series-coupe-red-star-spoke-384.jpg"
             />
@@ -73,7 +73,7 @@
         <field name="name">Coupé Red Rims 387</field>
         <field name="product_tmpl_id" ref="bmw_2_series" />
         <field
-                name="image_1920"
+                name="image"
                 type="base64"
                 file="product_configurator/static/img/2-series-coupe-red-star-spoke-387.jpg"
             />
@@ -90,7 +90,7 @@
         <field name="name">Coupé Silver Rims 384</field>
         <field name="product_tmpl_id" ref="bmw_2_series" />
         <field
-                name="image_1920"
+                name="image"
                 type="base64"
                 file="product_configurator/static/img/2-series-coupe-silver-star-spoke-384.jpg"
             />
@@ -107,7 +107,7 @@
         <field name="name">Coupé Silver Rims 387</field>
         <field name="product_tmpl_id" ref="bmw_2_series" />
         <field
-                name="image_1920"
+                name="image"
                 type="base64"
                 file="product_configurator/static/img/2-series-coupe-silver-star-spoke-387.jpg"
             />
@@ -124,7 +124,7 @@
         <field name="name">Coupé Black Rims 384</field>
         <field name="product_tmpl_id" ref="bmw_2_series" />
         <field
-                name="image_1920"
+                name="image"
                 type="base64"
                 file="product_configurator/static/img/2-series-coupe-black-star-spoke-384.jpg"
             />
@@ -141,7 +141,7 @@
         <field name="name">Coupé Black Rims 387</field>
         <field name="product_tmpl_id" ref="bmw_2_series" />
         <field
-                name="image_1920"
+                name="image"
                 type="base64"
                 file="product_configurator/static/img/2-series-coupe-black-star-spoke-387.jpg"
             />

--- a/product_configurator/demo/product_template.xml
+++ b/product_configurator/demo/product_template.xml
@@ -18,7 +18,7 @@
         <field name="categ_id" ref="product_category_bmw" />
         <field name="list_price" eval="25000" />
         <field
-                name="image_1920"
+                name="image"
                 type="base64"
                 file="product_configurator/static/img/2-series-coupe.jpg"
             />
@@ -31,7 +31,7 @@
         <field name="type">consu</field>
         <field name="lst_price" eval="0" />
         <field
-                name="image_1920"
+                name="image"
                 type="base64"
                 file="product_configurator/static/img/product-sport-line.jpg"
             />
@@ -42,7 +42,7 @@
         <field name="type">consu</field>
         <field name="lst_price" eval="0" />
         <field
-                name="image_1920"
+                name="image"
                 type="base64"
                 file="product_configurator/static/img/product-luxury-line.jpg"
             />
@@ -53,7 +53,7 @@
         <field name="type">consu</field>
         <field name="lst_price" eval="2666" />
         <field
-                name="image_1920"
+                name="image"
                 type="base64"
                 file="product_configurator/static/img/product-sport-line.jpg"
             />
@@ -64,7 +64,7 @@
         <field name="type">consu</field>
         <field name="lst_price" eval="3844" />
         <field
-                name="image_1920"
+                name="image"
                 type="base64"
                 file="product_configurator/static/img/product-luxury-line.jpg"
             />
@@ -75,7 +75,7 @@
         <field name="type">consu</field>
         <field name="lst_price" eval="4526" />
         <field
-                name="image_1920"
+                name="image"
                 type="base64"
                 file="product_configurator/static/img/product-m-sport.jpg"
             />
@@ -86,7 +86,7 @@
         <field name="type">consu</field>
         <field name="lst_price" eval="992" />
         <field
-                name="image_1920"
+                name="image"
                 type="base64"
                 file="product_configurator/static/img/product-advantage.jpg"
             />
@@ -97,7 +97,7 @@
         <field name="type">consu</field>
         <field name="lst_price" eval="0" />
         <field
-                name="image_1920"
+                name="image"
                 type="base64"
                 file="product_configurator/static/img/product-transmission-steptronic.jpg"
             />
@@ -108,7 +108,7 @@
         <field name="type">consu</field>
         <field name="lst_price" eval="156" />
         <field
-                name="image_1920"
+                name="image"
                 type="base64"
                 file="product_configurator/static/img/product-transmission-steptronic-sport.jpg"
             />
@@ -119,7 +119,7 @@
         <field name="type">consu</field>
         <field name="lst_price" eval="842" />
         <field
-                name="image_1920"
+                name="image"
                 type="base64"
                 file="product_configurator/static/img/product-sunroof.jpg"
             />
@@ -130,7 +130,7 @@
         <field name="type">consu</field>
         <field name="lst_price" eval="0" />
         <field
-                name="image_1920"
+                name="image"
                 type="base64"
                 file="product_configurator/static/img/product-armrest.jpg"
             />
@@ -141,7 +141,7 @@
         <field name="type">consu</field>
         <field name="lst_price" eval="842" />
         <field
-                name="image_1920"
+                name="image"
                 type="base64"
                 file="product_configurator/static/img/product-towhook.jpg"
             />
@@ -152,7 +152,7 @@
         <field name="type">consu</field>
         <field name="lst_price" eval="32" />
         <field
-                name="image_1920"
+                name="image"
                 type="base64"
                 file="product_configurator/static/img/product-smoker-package.jpg"
             />
@@ -163,7 +163,7 @@
         <field name="type">consu</field>
         <field name="lst_price" eval="4078" />
         <field
-                name="image_1920"
+                name="image"
                 type="base64"
                 file="product_configurator/static/img/product-engine.jpg"
             />
@@ -174,7 +174,7 @@
         <field name="type">consu</field>
         <field name="lst_price" eval="7240" />
         <field
-                name="image_1920"
+                name="image"
                 type="base64"
                 file="product_configurator/static/img/product-engine.jpg"
             />
@@ -185,7 +185,7 @@
         <field name="type">consu</field>
         <field name="lst_price" eval="12634" />
         <field
-                name="image_1920"
+                name="image"
                 type="base64"
                 file="product_configurator/static/img/product-engine.jpg"
             />
@@ -196,7 +196,7 @@
         <field name="type">consu</field>
         <field name="lst_price" eval="23236" />
         <field
-                name="image_1920"
+                name="image"
                 type="base64"
                 file="product_configurator/static/img/product-engine.jpg"
             />
@@ -207,7 +207,7 @@
         <field name="type">consu</field>
         <field name="lst_price" eval="23236" />
         <field
-                name="image_1920"
+                name="image"
                 type="base64"
                 file="product_configurator/static/img/product-engine.jpg"
             />
@@ -218,7 +218,7 @@
         <field name="type">consu</field>
         <field name="lst_price" eval="7116" />
         <field
-                name="image_1920"
+                name="image"
                 type="base64"
                 file="product_configurator/static/img/product-engine.jpg"
             />
@@ -229,7 +229,7 @@
         <field name="type">consu</field>
         <field name="lst_price" eval="9596" />
         <field
-                name="image_1920"
+                name="image"
                 type="base64"
                 file="product_configurator/static/img/product-engine.jpg"
             />
@@ -240,7 +240,7 @@
         <field name="type">consu</field>
         <field name="lst_price" eval="16181" />
         <field
-                name="image_1920"
+                name="image"
                 type="base64"
                 file="product_configurator/static/img/product-engine.jpg"
             />
@@ -251,7 +251,7 @@
         <field name="type">consu</field>
         <field name="lst_price" eval="16987" />
         <field
-                name="image_1920"
+                name="image"
                 type="base64"
                 file="product_configurator/static/img/product-engine.jpg"
             />
@@ -262,7 +262,7 @@
         <field name="type">consu</field>
         <field name="lst_price" eval="726" />
         <field
-                name="image_1920"
+                name="image"
                 type="base64"
                 file="product_configurator/static/img/product-paint-silver.jpg"
             />

--- a/product_configurator/models/product.py
+++ b/product_configurator/models/product.py
@@ -125,7 +125,7 @@ class ProductTemplate(models.Model):
     )
     weight_dummy = fields.Float(
         string="Manual Weight",
-        digits="Stock Weight",
+        digits=(16, 4),
         help="Manual setting of product template weight",
     )
 
@@ -138,7 +138,7 @@ class ProductTemplate(models.Model):
 
     def _set_weight(self):
         for product_tmpl in self:
-            product_tmpl.weight_dummy = product_tmpl.weight
+            # product_tmpl.weight_dummy = product_tmpl.weight
             if not product_tmpl.config_ok:
                 super(ProductTemplate, product_tmpl)._set_weight()
 
@@ -484,7 +484,7 @@ class ProductProduct(models.Model):
     weight_extra = fields.Float(
         string="Weight Extra", compute="_compute_product_weight_extra"
     )
-    weight_dummy = fields.Float(string="Manual Weight", digits="Stock Weight")
+    weight_dummy = fields.Float(string="Manual Weight", digits=(16, 4))
     weight = fields.Float(
         compute="_compute_product_weight",
         inverse="_inverse_product_weight",
@@ -598,7 +598,7 @@ class ProductProduct(models.Model):
             products_to_update += cfg_product
         return products_to_update
 
-    @api.depends_context("product_sessions")
+    # @api.depends_context("product_sessions")
     def _compute_product_price(self):
         session_map = self.env.context.get("product_sessions", ())
         if isinstance(session_map, tuple):

--- a/product_configurator/models/product_attribute.py
+++ b/product_configurator/models/product_attribute.py
@@ -196,13 +196,13 @@ class ProductAttributeLine(models.Model):
                     )
                 )
 
-    @api.constrains("active", "value_ids", "attribute_id")
+    @api.constrains("value_ids", "attribute_id")
     def _check_valid_values(self):
         """Overwrite to save attribute line without
         values when custom is true"""
         for ptal in self:
             # Customization
-            if ptal.active and not ptal.value_ids and not ptal.custom:
+            if not ptal.value_ids and not ptal.custom:
                 # Old code
                 # if ptal.active and not ptal.value_ids:
                 # Customization End
@@ -373,7 +373,7 @@ class ProductAttributePrice(models.Model):
     # Leverage product.template.attribute.value to compute the extra weight
     # each attribute adds
 
-    weight_extra = fields.Float(string="Attribute Weight Extra", digits="Stock Weight")
+    weight_extra = fields.Float(string="Attribute Weight Extra", digits=(16, 4))
 
 
 class ProductAttributeValueLine(models.Model):

--- a/product_configurator/models/product_config.py
+++ b/product_configurator/models/product_config.py
@@ -3,6 +3,9 @@ from ast import literal_eval
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
 from odoo.tools.misc import formatLang
+import logging
+
+_logger = logging.getLogger(__name__)
 
 
 class ProductConfigDomain(models.Model):
@@ -230,11 +233,12 @@ class ProductConfigLine(models.Model):
 
 class ProductConfigImage(models.Model):
     _name = "product.config.image"
-    _inherit = ["image.mixin"]
+    # _inherit = ["image.mixin"]
     _description = "Product Config Image"
     _order = "sequence"
 
     name = fields.Char("Name", required=True, translate=True)
+    image = fields.Binary("Image")
     product_tmpl_id = fields.Many2one(
         comodel_name="product.template",
         string="Product",
@@ -335,7 +339,7 @@ class ProductConfigSession(models.Model):
                 price = session.get_cfg_price()
             else:
                 price = 0.00
-            session.price = price
+            # session.price = price
 
     def get_custom_value_id(self):
         """Return record set of attribute value 'custom'"""
@@ -467,7 +471,7 @@ class ProductConfigSession(models.Model):
         compute="_compute_cfg_price",
         string="Price",
         store=True,
-        digits="Product Price",
+        digits=(16, 4),
     )
     currency_id = fields.Many2one(
         comodel_name="res.currency",
@@ -481,7 +485,7 @@ class ProductConfigSession(models.Model):
         default="draft",
     )
     weight = fields.Float(
-        string="Weight", compute="_compute_cfg_weight", digits="Stock Weight"
+        string="Weight", compute="_compute_cfg_weight", digits=(16, 4)
     )
     # Product preset
     product_preset_id = fields.Many2one(
@@ -709,6 +713,7 @@ class ProductConfigSession(models.Model):
                     _("Default values provided generate an invalid " "configuration")
                 )
             vals.update({"value_ids": [(6, 0, default_val_ids)]})
+        # import pdb; pdb.set_trace()
         return super(ProductConfigSession, self).create(vals)
 
     def create_get_variant(self, value_ids=None, custom_vals=None):
@@ -865,7 +870,7 @@ class ProductConfigSession(models.Model):
         config_image_id = self._get_config_image(
             value_ids=value_ids, custom_vals=custom_vals
         )
-        return config_image_id.image_1920
+        return config_image_id.image
 
     @api.model
     def get_variant_vals(self, value_ids=None, custom_vals=None, **kwargs):
@@ -895,7 +900,7 @@ class ProductConfigSession(models.Model):
             "product_tmpl_id": self.product_tmpl_id.id,
             "product_template_attribute_value_ids": [(6, 0, ptav_ids.ids)],
             "taxes_id": [(6, 0, self.product_tmpl_id.taxes_id.ids)],
-            "image_1920": image,
+            "image": image,
         }
         return vals
 
@@ -1457,6 +1462,7 @@ class ProductConfigSession(models.Model):
             parent_id=parent_id,
             user_id=user_id,
         )
+        _logger.info(vals)
         return self.create(vals)
 
     # TODO: Disallow duplicates

--- a/product_configurator/views/product_attribute_view.xml
+++ b/product_configurator/views/product_attribute_view.xml
@@ -35,55 +35,60 @@
             <xpath expr="//field[@name='create_variant']" position="attributes">
                 <attribute name="groups">base.group_no_one</attribute>
             </xpath>
+            <group name="values_ids" position="after">
+                <notebook>
+                    <page
+                            string="Configurator"
+                            groups="product_configurator.group_product_configurator_manager"
+                            invisible="not context.get('flag_config_ok')"
+                        >
+                        <group>
+                            <group>
+                                <field name="required" />
+                                <field
+                                        name="multi"
+                                        attrs="{'readonly': [('val_custom','=',True)]}"
+                                        force_save="1"
+                                    />
+                                <field
+                                        name="val_custom"
+                                        attrs="{'readonly': [('multi', '=', True)]}"
+                                        force_save="1"
+                                    />
+                            </group>
+                            <group>
+                                <field name="uom_id" />
+                            </group>
+                            <field name="description" colspan="4" />
+                        </group>
+                    </page>
+                    <page
+                            string="Custom Values"
+                            invisible="not context.get('flag_config_ok')"
+                            attrs="{'invisible': [('val_custom', '!=', True)]}"
+                            groups="product_configurator.group_product_configurator_manager"
+                        >
+                        <group>
+                            <group>
+                                <field name="custom_type" />
+                                <field
+                                        name="min_val"
+                                        attrs="{'invisible': [('custom_type','not in',['integer','float'])]}"
+                                    />
+                                <field
+                                        name="max_val"
+                                        attrs="{'invisible': [('custom_type','not in',['integer','float'])]}"
+                                    />
+                            </group>
+                            <group>
+                                <field name="search_ok" />
+                            </group>
+                        </group>
+                    </page>
+                </notebook>
+            </group>
             <xpath expr="//notebook//page" position="after">
-                <page
-                        string="Configurator"
-                        groups="product_configurator.group_product_configurator_manager"
-                        invisible="not context.get('flag_config_ok')"
-                    >
-                    <group>
-                        <group>
-                            <field name="required" />
-                            <field
-                                    name="multi"
-                                    attrs="{'readonly': [('val_custom','=',True)]}"
-                                    force_save="1"
-                                />
-                            <field
-                                    name="val_custom"
-                                    attrs="{'readonly': [('multi', '=', True)]}"
-                                    force_save="1"
-                                />
-                        </group>
-                        <group>
-                            <field name="uom_id" />
-                        </group>
-                        <field name="description" colspan="4" />
-                    </group>
-                </page>
-                <page
-                        string="Custom Values"
-                        invisible="not context.get('flag_config_ok')"
-                        attrs="{'invisible': [('val_custom', '!=', True)]}"
-                        groups="product_configurator.group_product_configurator_manager"
-                    >
-                    <group>
-                        <group>
-                            <field name="custom_type" />
-                            <field
-                                    name="min_val"
-                                    attrs="{'invisible': [('custom_type','not in',['integer','float'])]}"
-                                />
-                            <field
-                                    name="max_val"
-                                    attrs="{'invisible': [('custom_type','not in',['integer','float'])]}"
-                                />
-                        </group>
-                        <group>
-                            <field name="search_ok" />
-                        </group>
-                    </group>
-                </page>
+
             </xpath>
         </field>
     </record>

--- a/product_configurator/views/product_view.xml
+++ b/product_configurator/views/product_view.xml
@@ -214,7 +214,7 @@
                                     widget="many2many_tags"
                                     context="{'_cfg_product_tmpl_id': parent.id}"
                                 />
-                        <field name="image_1920" widget="image" height="30px" />
+                        <field name="image" widget="image" height="30px" />
                     </tree>
                 </field>
                 <field name="attribute_line_val_ids" invisible="1" />
@@ -324,6 +324,7 @@
         <field name="inherit_id" ref="product.product_normal_form_view" />
         <field name="arch" type="xml">
             <xpath expr='//header' position="inside">
+                <field name="product_template_attribute_value_ids" invisible="1"/>
                 <button
                         string="Variant Prices"
                         type="object"

--- a/product_configurator/wizard/product_configurator.py
+++ b/product_configurator/wizard/product_configurator.py
@@ -4,7 +4,7 @@ from odoo import _, api, fields, models, tools
 from odoo.exceptions import UserError, ValidationError
 
 from odoo.addons.base.models.ir_model import FIELD_TYPES
-from odoo.addons.base.models.ir_ui_view import (
+from odoo.osv.orm import (
     transfer_field_to_modifiers,
     transfer_modifiers_to_node,
     transfer_node_to_modifiers,
@@ -579,7 +579,7 @@ class ProductConfigurator(models.TransientModel):
             node=node,
             modifiers=modifiers,
             context=context,
-            current_node_path=current_node_path,
+            in_tree_view=current_node_path,
         )
         transfer_modifiers_to_node(modifiers=modifiers, node=node)
 

--- a/product_configurator_mrp/__manifest__.py
+++ b/product_configurator_mrp/__manifest__.py
@@ -19,7 +19,7 @@
     ],
     "demo": ["demo/product_template.xml"],
     "qweb": ["static/src/xml/mrp_production_views.xml"],
-    "installable": True,
+    "installable": False,
     "auto_install": False,
     "development_status": "Beta",
     "maintainers": ["pcatinean"],

--- a/product_configurator_mrp/__manifest__.py
+++ b/product_configurator_mrp/__manifest__.py
@@ -19,7 +19,7 @@
     ],
     "demo": ["demo/product_template.xml"],
     "qweb": ["static/src/xml/mrp_production_views.xml"],
-    "installable": False,
+    "installable": True,
     "auto_install": False,
     "development_status": "Beta",
     "maintainers": ["pcatinean"],

--- a/product_configurator_mrp/views/mrp_view.xml
+++ b/product_configurator_mrp/views/mrp_view.xml
@@ -27,7 +27,7 @@
                     />
                 </div>
             </xpath>
-            <page name="finished_products" position="after">
+            <xpath expr="//notebook/page[2]" position="after">
                 <page string="Custom Values" name="custom_values">
                     <field name="custom_value_ids" readonly="True" force_save="True">
                         <tree>
@@ -37,7 +37,7 @@
                         </tree>
                     </field>
                 </page>
-            </page>
+            </xpath>
         </field>
     </record>
 
@@ -66,7 +66,7 @@
     <record id="mrp.mrp_production_action" model="ir.actions.act_window">
         <field
             name="context"
-        >{"search_default_todo": True, "default_company_id": allowed_company_ids[0], "custom_create_variant": True}</field>
+        >{"search_default_todo": True, "default_company_id": context.get('company_id'), "custom_create_variant": True}</field>
     </record>
 
     <record id="mrp_bom_form_view" model="ir.ui.view">
@@ -87,7 +87,7 @@
             </xpath>
 
             <xpath
-                expr="//field[@name='bom_product_template_attribute_value_ids']"
+                expr="//field[@name='attribute_value_ids']"
                 position="attributes"
             >
                 <attribute
@@ -96,7 +96,7 @@
             </xpath>
 
              <xpath
-                expr="//field[@name='bom_product_template_attribute_value_ids']"
+                expr="//field[@name='attribute_value_ids']"
                 position="after"
             >
                 <field

--- a/product_configurator_purchase/__manifest__.py
+++ b/product_configurator_purchase/__manifest__.py
@@ -15,7 +15,7 @@
     "demo": ["demo/product_template.xml"],
     "images": [],
     "test": [],
-    "installable": True,
+    "installable": False,
     "auto_install": False,
     "development_status": "Beta",
     "maintainers": ["pcatinean"],

--- a/product_configurator_restriction_policy/__manifest__.py
+++ b/product_configurator_restriction_policy/__manifest__.py
@@ -15,6 +15,6 @@
         "views/product_view.xml",
     ],
     "development_status": "Beta",
-    "installable": True,
+    "installable": False,
     "application": False,
 }

--- a/product_configurator_sale/__manifest__.py
+++ b/product_configurator_sale/__manifest__.py
@@ -15,7 +15,7 @@
         "views/sale_view.xml",
     ],
     "demo": ["demo/res_partner_demo.xml"],
-    "installable": True,
+    "installable": False,
     "auto_install": False,
     "development_status": "Beta",
     "maintainers": ["pcatinean"],

--- a/product_configurator_sale_mrp/__manifest__.py
+++ b/product_configurator_sale_mrp/__manifest__.py
@@ -10,8 +10,8 @@
     "license": "AGPL-3",
     "website": "https://github.com/OCA/product-configurator",
     "depends": ["sale_mrp", "product_configurator_sale", "product_configurator_mrp"],
-    "installable": True,
-    "auto_install": True,
+    "installable": False,
+    "auto_install": False,
     "development_status": "Beta",
     "maintainers": ["pcatinean"],
 }

--- a/product_configurator_stock/__manifest__.py
+++ b/product_configurator_stock/__manifest__.py
@@ -17,7 +17,7 @@
         "views/product_view.xml",
     ],
     "demo": ["demo/product_template.xml"],
-    "installable": True,
+    "installable": False,
     "development_status": "Beta",
     "maintainers": ["pcatinean"],
     "auto_install": False,

--- a/website_product_configurator/__manifest__.py
+++ b/website_product_configurator/__manifest__.py
@@ -24,7 +24,7 @@
     "demo": ["demo/product_template_demo.xml"],
     "images": ["static/description/cover.png"],
     "application": True,
-    "installable": True,
+    "installable": False,
     "development_status": "Beta",
     "maintainers": ["pcatinean"],
 }

--- a/website_product_configurator_mrp/__manifest__.py
+++ b/website_product_configurator_mrp/__manifest__.py
@@ -10,7 +10,7 @@
     "depends": ["product_configurator_mrp", "website_product_configurator"],
     "data": ["views/templates.xml", "views/assets.xml"],
     "application": True,
-    "installable": True,
+    "installable": False,
     "development_status": "Beta",
     "maintainers": ["pcatinean"],
     "auto_install": False,


### PR DESCRIPTION
This Pull Request starts the backport of the module product_configurator to the 12.0 version. The module is installable and its functions are working minimally. All other modules, not backported are set with `installable=False` in their manifest.