### PR TITLE
[14.0][FIX] product_configurator_sale: avoid other module inheritance issues

### DIFF
--- a/product_configurator_sale/views/sale_view.xml
+++ b/product_configurator_sale/views/sale_view.xml
@@ -40,6 +40,12 @@
                 />
                 <field name="config_session_id" />
             </xpath>
+            <!--
+            The line form extension was removed.
+            Cases were found where it was causing install errors on other modules,
+            that were extending order line (for example sale-workflow/sale_product_approval,
+            adding a column after the sales order name field.
+
             <xpath
                 expr="//form//notebook//field[@name='order_line']/form/field[@name='name']"
                 position="after"
@@ -55,6 +61,7 @@
                     </field>
                 </div>
             </xpath>
+            -->
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
When product configurator is installed, some other modules then
fail to install. It seems that it happens when they are also extending
sales order lines, to add columns to the nested tree, after the "name"
field.

This is probably a subtle bug in the Odoo core, but the pragmatic
solution seems to simplify the Product Configurator sales order form
extensions.
