### PR TITLE
[FIX] product_configurator: unnecessary `price_compute` function

### DIFF
--- a/product_configurator/models/product.py
+++ b/product_configurator/models/product.py
@@ -611,15 +611,3 @@ class ProductProduct(models.Model):
             )
             cfg_product.price = product_session.price
         super(ProductProduct, standard_products)._compute_product_price()
-
-    def price_compute(self, price_type, uom=False, currency=False, company=False):
-        standard_products = self.filtered(lambda a: not a.config_ok)
-        res = {}
-        if standard_products:
-            res = super(ProductProduct, standard_products).price_compute(
-                price_type, uom=uom, currency=currency, company=company
-            )
-        config_products = self - standard_products
-        for config_product in config_products:
-            res[config_product.id] = config_product.price
-        return res


### PR DESCRIPTION
With `price_compute` function, price will always be set to 0 if the product is from configurator module.

Before changes:

https://user-images.githubusercontent.com/38809768/136955581-87c4d042-de53-4e84-9006-8e94318bd05d.mp4

After changes:

https://user-images.githubusercontent.com/38809768/136955640-f300a8b5-1619-4498-8da1-47787103c528.mp4



