### PR TITLE
[FIX] product_configurator_mrp (Variant BoM Components Duplicated)

### DIFF
--- a/product_configurator_mrp/models/product_config.py
+++ b/product_configurator_mrp/models/product_config.py
@@ -67,25 +67,22 @@ class ProductConfigSession(models.Model):
                     for config in parent_bom_line.config_set_id.configuration_ids:
                         # Add bom lines if config values are part of attr_values
                         if set(config.value_ids.ids).issubset(set(attr_values.ids)):
-                            for (
-                                config_bom_line
-                            ) in parent_bom_line.config_set_id.bom_line_ids:
-                                if config_bom_line.bom_id.id == parent_bom.id:
-                                    parent_bom_line_vals = {
-                                        "product_id": config_bom_line.product_id.id
-                                    }
-                                    specs = self.get_onchange_specifications(
-                                        model="mrp.bom.line"
-                                    )
-                                    updates = mrpBomLine.onchange(
-                                        parent_bom_line_vals, ["product_id"], specs
-                                    )
-                                    values = updates.get("value", {})
-                                    values = self.get_vals_to_write(
-                                        values=values, model="mrp.bom.line"
-                                    )
-                                    values.update(parent_bom_line_vals)
-                                    bom_lines.append((0, 0, values))
+                            if parent_bom_line.bom_id.id == parent_bom.id:
+                                parent_bom_line_vals = {
+                                    "product_id": parent_bom_line.product_id.id
+                                }
+                                specs = self.get_onchange_specifications(
+                                    model="mrp.bom.line"
+                                )
+                                updates = mrpBomLine.onchange(
+                                    parent_bom_line_vals, ["product_id"], specs
+                                )
+                                values = updates.get("value", {})
+                                values = self.get_vals_to_write(
+                                    values=values, model="mrp.bom.line"
+                                )
+                                values.update(parent_bom_line_vals)
+                                bom_lines.append((0, 0, values))
                 else:
                     parent_bom_line_vals = {"product_id": parent_bom_line.product_id.id}
                     specs = self.get_onchange_specifications(model="mrp.bom.line")

--- a/product_configurator_mrp/models/product_config.py
+++ b/product_configurator_mrp/models/product_config.py
@@ -72,7 +72,7 @@ class ProductConfigSession(models.Model):
                             if parent_bom_line.bom_id.id == parent_bom.id:
                                 parent_bom_line_vals = {
                                     "product_id": parent_bom_line.product_id.id,
-                                    "product_qty": config_bom_line.product_qty,
+                                    "product_qty": parent_bom_line.product_qty,
                                 }
                                 specs = self.get_onchange_specifications(
                                     model="mrp.bom.line"


### PR DESCRIPTION
Fix for issue https://github.com/OCA/product-configurator/issues/59

When there are multiple components that use the same configuration set on the parent bom, duplicate components would be generated on the variant bom.