### PR TITLE
[FIX] product_configurator

### DIFF
--- a/product_configurator/models/product.py
+++ b/product_configurator/models/product.py
@@ -147,7 +147,9 @@ class ProductTemplate(models.Model):
 
     def get_product_attribute_values_action(self):
         self.ensure_one()
-        action = self.env.ref("product.product_attribute_value_action").read()[0]
+        action = self.env["ir.actions.actions"]._for_xml_id(
+            "product.product_attribute_value_action"
+        )
         value_ids = self.attribute_line_ids.mapped("product_template_value_ids").ids
         action["domain"] = [("id", "in", value_ids)]
         context = safe_eval(action["context"], {"active_id": self.id})
@@ -497,7 +499,9 @@ class ProductProduct(models.Model):
 
     def get_product_attribute_values_action(self):
         self.ensure_one()
-        action = self.env.ref("product.product_attribute_value_action").read()[0]
+        action = self.env["ir.actions.actions"]._for_xml_id(
+            "product.product_attribute_value_action"
+        )
         value_ids = self.product_template_attribute_value_ids.ids
         action["domain"] = [("id", "in", value_ids)]
         context = safe_eval(action["context"], {"active_id": self.product_tmpl_id.id})


### PR DESCRIPTION
* ordinary users don't have access to `act_window`

Test was performed with demo data only

Before:

https://user-images.githubusercontent.com/38809768/157641052-ec320e67-9d95-49b9-8bcb-b29c9824fd01.mp4

After changes:

https://user-images.githubusercontent.com/38809768/157641495-e5dc865d-318f-43c9-add4-55f83d0d97d8.mp4


