### PR TITLE
[FIX] product_configurator_mrp_component: configurable component selection and variant creation

### DIFF
--- a/product_configurator_mrp_component/models/mrp_bom.py
+++ b/product_configurator_mrp_component/models/mrp_bom.py
@@ -52,7 +52,7 @@ class MRPBoM(models.Model):
                                 lambda m: m.attribute_id == attribute_line.attribute_id
                             )
                             # If bom prod has all vals that conf comp has then add it
-                            if all(att_val in prod_vals for att_val in bom_tmpl_values):
+                            if all(att_val in bom_tmpl_values for att_val in prod_vals):
                                 bom.available_config_components = [(4, prod.id)]
 
 

--- a/product_configurator_mrp_component/models/product_config.py
+++ b/product_configurator_mrp_component/models/product_config.py
@@ -17,54 +17,68 @@ class ProductConfigSession(models.Model):
             limit=1,
         )
         vals = False
+        wizard_values = variant.product_template_attribute_value_ids.mapped(
+            "product_attribute_value_id"
+        )
         for config_component_line in master_bom.bom_line_config_ids:
-            wizard_values = variant.product_template_attribute_value_ids.mapped(
-                "product_attribute_value_id"
-            )
             config_component_vals = config_component_line.product_tmpl_id.mapped(
                 "attribute_line_ids.value_ids"
             )
             vals = set(wizard_values.ids).intersection(set(config_component_vals.ids))
-            component_config_session = self.create_get_session(
-                config_component_line.product_tmpl_id.id
-            )
-            component_config_session.write({"value_ids": [(6, 0, vals)]})
-            component_config_session.action_confirm()
-            component_variant = component_config_session.product_id
 
-            # Look for existing configuration set and if doesn't exist, create it.
-            bom_line_config_set = self.env["mrp.bom.line.configuration.set"].search(
-                [("name", "=", component_variant.display_name)],
-                limit=1,
-            )
-            if not bom_line_config_set:
-                bom_line_config_set = self.env["mrp.bom.line.configuration.set"].create(
-                    {
-                        "name": component_variant.display_name,
-                    }
+            # Bypass config component variant creation if not all required vals are set
+            do_not_create = False
+            for line in config_component_line.product_tmpl_id.attribute_line_ids:
+                common_vals = set(vals) & set(line.value_ids.ids)
+                if line.required and not common_vals:
+                    do_not_create = True
+            if do_not_create:
+                continue
+
+            # Otherwise create config component variant and bom
+            else:
+                component_config_session = self.create_get_session(
+                    config_component_line.product_tmpl_id.id
                 )
-                self.env["mrp.bom.line.configuration"].create(
-                    {
-                        "config_set_id": bom_line_config_set.id,
-                        "value_ids": [(6, 0, vals)],
-                    }
+                component_config_session.write({"value_ids": [(6, 0, vals)]})
+                component_config_session.action_confirm()
+                component_variant = component_config_session.product_id
+
+                # Look for existing configuration set and if doesn't exist, create it.
+                bom_line_config_set = self.env["mrp.bom.line.configuration.set"].search(
+                    [("name", "=", component_variant.display_name)],
+                    limit=1,
                 )
-            # Look for existing bom line and if doesn't exist, create it.
-            existing_bom_line = self.env["mrp.bom.line"].search(
-                [
-                    ("bom_id", "=", master_bom.id),
-                    ("product_id", "=", component_config_session.product_id.id),
-                    ("config_set_id", "=", bom_line_config_set.id),
-                ],
-                limit=1,
-            )
-            if not existing_bom_line:
-                self.env["mrp.bom.line"].create(
-                    {
-                        "bom_id": master_bom.id,
-                        "product_id": component_variant.id,
-                        "config_set_id": bom_line_config_set.id,
-                        "product_qty": config_component_line.product_qty,
-                    }
+                if not bom_line_config_set:
+                    bom_line_config_set = self.env[
+                        "mrp.bom.line.configuration.set"
+                    ].create(
+                        {
+                            "name": component_variant.display_name,
+                        }
+                    )
+                    self.env["mrp.bom.line.configuration"].create(
+                        {
+                            "config_set_id": bom_line_config_set.id,
+                            "value_ids": [(6, 0, vals)],
+                        }
+                    )
+                # Look for existing bom line and if doesn't exist, create it.
+                existing_bom_line = self.env["mrp.bom.line"].search(
+                    [
+                        ("bom_id", "=", master_bom.id),
+                        ("product_id", "=", component_config_session.product_id.id),
+                        ("config_set_id", "=", bom_line_config_set.id),
+                    ],
+                    limit=1,
                 )
+                if not existing_bom_line:
+                    self.env["mrp.bom.line"].create(
+                        {
+                            "bom_id": master_bom.id,
+                            "product_id": component_variant.id,
+                            "config_set_id": bom_line_config_set.id,
+                            "product_qty": config_component_line.product_qty,
+                        }
+                    )
         return super().create_get_bom(variant, product_tmpl_id=None, values=None)


### PR DESCRIPTION
1. Fixes issue where if config component only has a few values in an attribute and the parent has and the selected value is not in the configurable component, an error would be raised. The fix is don't create and add the component if this is the case. This was causing an error because it was trying to create the variant even if the value selected didn't apply to the config component. This will allow more flexibility with config components.

2. Fixes issue where the available configuration components that show in the drop down wasn't showing all the compatible product templates. It would show if the first attribute only had a few of the values but any attribute below that would have to have all the values in order for it to show.