### PR TITLE
[IMP] website_product_configurator (Cron noupdate)

### DIFF
--- a/website_product_configurator/data/cron.xml
+++ b/website_product_configurator/data/cron.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding='UTF-8' ?>
-<odoo>
+<odoo noupdate="1">
     <record id="cron_delete_sessions_with_no_activity" model="ir.cron">
         <field name="name">Delete inactive config-sessions</field>
         <field name="active" eval="True" />


### PR DESCRIPTION
The scheduled action shouldn't be overridden during updates incase it's disabled on purpose (we don't want it to re-enable) so this PR adds the noupdate flag.