### PR TITLE
[FIX] product_configurator (Sessions being removed)

### DIFF
--- a/product_configurator/wizard/product_configurator.py
+++ b/product_configurator/wizard/product_configurator.py
@@ -888,12 +888,6 @@ class ProductConfigurator(models.TransientModel):
 
         return super(ProductConfigurator, self).write(vals)
 
-    def unlink(self):
-        """Remove parent configuration session along with wizard"""
-
-        self.mapped("config_session_id").unlink()
-        return super(ProductConfigurator, self).unlink()
-
     def action_next_step(self):
         """Proceeds to the next step of the configuration process. This usually
         implies the next configuration step (if any) defined via the

--- a/product_configurator_mrp_component/models/mrp_bom.py
+++ b/product_configurator_mrp_component/models/mrp_bom.py
@@ -19,8 +19,8 @@ class MRPBoM(models.Model):
     @api.depends("bom_line_config_ids", "product_tmpl_id")
     def _compute_available_config_components(self):
         """Compute list of products available for configurable components"""
-        if self.config_ok and not self.product_id:
-            for bom in self:
+        for bom in self:
+            if bom.config_ok and not bom.product_id:
                 bom.available_config_components = False
                 products = self.env["product.template"].search(
                     [


### PR DESCRIPTION
The product.config.session model is a regular model however the wizards that inherit are set a transient models. This is causing sessions to be deleted when the vacuum cleaner runs. Since sessions can contain important information like custom values, they shouldn't be deleted by the vacuum so this changes the transient models to regular models.

If it's desired to 'clean' sessions periodically a scheduled action is suggested as it can provide more control over cleanup depending on individual needs.