### PR TITLE
[14.0] [FIX] product_configurator_mrp product_qty

### DIFF
--- a/product_configurator_mrp/models/product_config.py
+++ b/product_configurator_mrp/models/product_config.py
@@ -52,7 +52,7 @@ class ProductConfigSession(models.Model):
             # If not Bom, then Cycle through attributes to add their
             # related products to the bom lines.
             for product in attr_products:
-                bom_line_vals = {"product_id": product.id}
+                bom_line_vals = {"product_id": product.id, "product_qty": 1}
                 specs = self.get_onchange_specifications(model="mrp.bom.line")
                 updates = mrpBomLine.onchange(
                     bom_line_vals, ["product_id", "product_qty"], specs


### PR DESCRIPTION
Correction of bug access key "product_qty" not in dictionary