### PR TITLE
[FIX][14.0] product_configurator_mrp (Workrders Not Being Created)

### DIFF
--- a/product_configurator_mrp/wizard/product_configurator_mrp.py
+++ b/product_configurator_mrp/wizard/product_configurator_mrp.py
@@ -83,6 +83,7 @@ class ProductConfiguratorMrp(models.TransientModel):
             mrp_order = self.order_id.create(line_vals)
         mrp_order.onchange_product_id()
         mrp_order._onchange_bom_id()
+        mrp_order._onchange_workorder_ids()
         mrp_order._onchange_date_planned_start()
         mrp_order._onchange_move_raw()
         mrp_order._onchange_move_finished()


### PR DESCRIPTION
When configuring a product on a Manufacturing order, work orders don't get created. This is because the on-change method that usually is run to add the work orders isn't being run in the wizard. This PR fixes that.