### PR TITLE
[14.0][FIX] product_configurator_mrp (Operation Steps/Pick Type Onchange)

### DIFF
--- a/product_configurator_mrp/models/product_config.py
+++ b/product_configurator_mrp/models/product_config.py
@@ -121,7 +121,9 @@ class ProductConfigSession(models.Model):
             mrp_bom_id = mrpBom.create(values)
             if mrp_bom_id and parent_bom:
                 for operation_line in parent_bom.operation_ids:
-                    operation_line.copy(default={"bom_id": mrp_bom_id.id})
+                    new_op = operation_line.copy(default={"bom_id": mrp_bom_id.id})
+                    for step in new_op.quality_point_ids:
+                        step.write({"product_ids": [(6, 0, [variant.id])]})
             return mrp_bom_id
         return False
 

--- a/product_configurator_mrp/wizard/product_configurator_mrp.py
+++ b/product_configurator_mrp/wizard/product_configurator_mrp.py
@@ -86,7 +86,9 @@ class ProductConfiguratorMrp(models.TransientModel):
         mrp_order._onchange_date_planned_start()
         mrp_order._onchange_move_raw()
         mrp_order._onchange_move_finished()
+        mrp_order.onchange_picking_type()
         mrp_order._onchange_location()
+        mrp_order._onchange_location_dest()
         mrp_action = self.get_mrp_production_action()
         mrp_action.update({"res_id": mrp_order.id})
         return mrp_action


### PR DESCRIPTION
This fixes an issue when a new variant is created, it creates the BoM with operations and steps, since it's copying the steps, the product on the steps gets set with the product template and not the new variant. So, when an MO is created for the variant, the work order steps don't show, because they don't apply to the variant. The change is to simply set the product on the step to the new variant.

Also adds running the picking type onchange to the wizard done method so the proper locations are set when the MO is created.