### PR TITLE
[FIX] product_configurator: non-stored weight field is changed to a stored one

### DIFF
--- a/product_configurator/__manifest__.py
+++ b/product_configurator/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Product Configurator",
-    "version": "14.0.1.2.6",
+    "version": "14.0.1.3.0",
     "category": "Generic Modules/Base",
     "summary": "Base for product configuration interface modules",
     "author": "Pledra, Odoo Community Association (OCA)",

--- a/product_configurator/models/product.py
+++ b/product_configurator/models/product.py
@@ -115,20 +115,13 @@ class ProductTemplate(models.Model):
         copy=True,
     )
 
-    # We are calculating weight of variants based on weight of
-    # product-template so that no need of compute and inverse on this
-    weight = fields.Float(
-        compute="_compute_weight",
-        inverse="_set_weight",  # pylint: disable=C8110
-        search="_search_weight",
-        store=False,
-    )
     weight_dummy = fields.Float(
         string="Manual Weight",
         digits="Stock Weight",
         help="Manual setting of product template weight",
     )
 
+    @api.depends("weight_dummy", "product_variant_ids", "product_variant_ids.weight")
     def _compute_weight(self):
         config_products = self.filtered(lambda template: template.config_ok)
         for product in config_products:
@@ -141,9 +134,6 @@ class ProductTemplate(models.Model):
             product_tmpl.weight_dummy = product_tmpl.weight
             if not product_tmpl.config_ok:
                 super(ProductTemplate, product_tmpl)._set_weight()
-
-    def _search_weight(self, operator, value):
-        return [("weight_dummy", operator, value)]
 
     def get_product_attribute_values_action(self):
         self.ensure_one()
@@ -471,6 +461,7 @@ class ProductProduct(models.Model):
                 product.mapped("product_template_attribute_value_ids.weight_extra")
             )
 
+    @api.depends("weight_dummy", "weight_extra", "product_tmpl_id.weight")
     def _compute_product_weight(self):
         for product in self:
             if product.config_ok:
@@ -478,9 +469,6 @@ class ProductProduct(models.Model):
                 product.weight = tmpl_weight + product.weight_extra
             else:
                 product.weight = product.weight_dummy
-
-    def _search_product_weight(self, operator, value):
-        return [("weight_dummy", operator, value)]
 
     def _inverse_product_weight(self):
         """Store weight in dummy field"""
@@ -490,14 +478,13 @@ class ProductProduct(models.Model):
         string="Configuration Name", compute="_compute_config_name"
     )
     weight_extra = fields.Float(
-        string="Weight Extra", compute="_compute_product_weight_extra"
+        string="Weight Extra", compute="_compute_product_weight_extra", store=True
     )
     weight_dummy = fields.Float(string="Manual Weight", digits="Stock Weight")
     weight = fields.Float(
         compute="_compute_product_weight",
         inverse="_inverse_product_weight",
-        search="_search_product_weight",
-        store=False,
+        store=True,
     )
 
     # product preset

--- a/product_configurator/tests/test_product.py
+++ b/product_configurator/tests/test_product.py
@@ -698,28 +698,7 @@ class TestProduct(ProductConfiguratorTestCases):
             Method: _get_config_name()",
         )
 
-    def test_23_search_product_weight(self):
-        product_product = self._get_product_id()
-        operator = "and"
-        value = 10
-        search_product_weight = product_product._search_product_weight(operator, value)
-        self.assertTrue(
-            search_product_weight,
-            "Error: If value False\
-            Method: _search_product_weight()",
-        )
-
-    def test_24_search_weight(self):
-        operator = "and"
-        value = 10
-        search_weight = self.product_tmpl_id._search_weight(operator, value)
-        self.assertTrue(
-            search_weight,
-            "Error: If value False\
-            Method: _search_weight()",
-        )
-
-    def test_25_check_config_line_domain(self):
+    def test_23_check_config_line_domain(self):
         product_config_line = self.env.ref(
             "product_configurator.product_config_line_218_lines"
         )


### PR DESCRIPTION
(Reopened from https://github.com/OCA/product-configurator/pull/71)
Correction of bug: original field weight is not-stored
Fix issue: https://github.com/OCA/product-configurator/issues/66