### PR TITLE
[FIX][14.0] product_configurator (product.template.attribute.value In-Active)

### DIFF
--- a/product_configurator/models/product_config.py
+++ b/product_configurator/models/product_config.py
@@ -888,6 +888,7 @@ class ProductConfigSession(models.Model):
             [
                 ("product_tmpl_id", "=", self.product_tmpl_id.id),
                 ("product_attribute_value_id", "in", value_ids),
+                ("ptav_active", "=", True),
             ]
         )
         vals = {


### PR DESCRIPTION
We found in a certain scenario, if a attribute/value is added twice to a product, then one is removed, the variant that gets created will contain both values. This is because the product.template.attribute.value doesn't have a normal 'active' field, instead has ptav_active so the search returns active and inactive values. 

This small code change fixes this issue.