### PR TITLE
[FIX] product_configurator: Wizard reset

### DIFF
--- a/product_configurator/__manifest__.py
+++ b/product_configurator/__manifest__.py
@@ -28,6 +28,7 @@
     "assets": {
         "web.assets_backend": [
             "/product_configurator/static/src/scss/form_widget.scss",
+            "/product_configurator/static/src/js/form_controller.esm.js",
             "/product_configurator/static/src/js/form_widgets.js",
             "/product_configurator/static/src/js/boolean_button_widget.esm.js",
             "/product_configurator/static/src/js/boolean_button_widget.xml",

--- a/product_configurator/static/src/js/form_controller.esm.js
+++ b/product_configurator/static/src/js/form_controller.esm.js
@@ -1,0 +1,14 @@
+/** @odoo-module **/
+
+import {FormController} from "@web/views/form/form_controller";
+import {patch} from "@web/core/utils/patch";
+
+patch(FormController.prototype, "Manage special=no_save", {
+    async beforeExecuteActionButton(clickParams) {
+        if (clickParams.special === "no_save") {
+            delete clickParams.special;
+            return true;
+        }
+        return this._super(...arguments);
+    },
+});

--- a/product_configurator/static/src/js/form_widgets.js
+++ b/product_configurator/static/src/js/form_widgets.js
@@ -37,14 +37,6 @@ odoo.define("product_configurator.FieldBooleanButton", function (require) {
                     record_ctx
                 );
             }
-            if (attrs.special === "no_save") {
-                this.canBeSaved = function () {
-                    return true;
-                };
-                var event_no_save = $.extend(true, {}, event);
-                event_no_save.data.attrs.special = false;
-                return this._super(event_no_save);
-            }
             this._super(event);
         },
     });


### PR DESCRIPTION
Steps:

1. Open a product in Configurator > Configurable templates
2. Click Configure product
3. Do a few steps
4. Click Reset and confirm

Actual behavior:
The old configuration session is used in the popup: the values already selected are still selected.

Expected behavior:
The configuration session is deleted and a new configuration can be started from scratch