### PR TITLE
[IMP] product_configurator: Price for custom values with formula

### DIFF
--- a/product_configurator/models/product_config.py
+++ b/product_configurator/models/product_config.py
@@ -1,9 +1,9 @@
 import logging
-from ast import literal_eval
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
 from odoo.tools.misc import flatten, formatLang
+from odoo.tools.safe_eval import safe_eval
 
 _logger = logging.getLogger(__name__)
 
@@ -343,6 +343,7 @@ class ProductConfigSession(models.Model):
 
     @api.depends(
         "value_ids",
+        "custom_value_ids.price",
         "product_tmpl_id.list_price",
         "product_tmpl_id.attribute_line_ids",
         "product_tmpl_id.attribute_line_ids.value_ids",
@@ -369,12 +370,11 @@ class ProductConfigSession(models.Model):
         {attribute_id: parsed_custom_value}"""
         custom_vals = {}
         for val in self.custom_value_ids:
-            if val.attribute_id.custom_type in ["float", "integer"]:
-                custom_vals[val.attribute_id.id] = literal_eval(val.value)
-            elif val.attribute_id.custom_type == "binary":
-                custom_vals[val.attribute_id.id] = val.attachment_ids
+            attribute = val.attribute_id
+            if attribute.custom_type == "binary":
+                custom_vals[attribute.id] = val.attachment_ids
             else:
-                custom_vals[val.attribute_id.id] = val.value
+                custom_vals[attribute.id] = val.eval()
         return custom_vals
 
     def _compute_config_step_name(self):
@@ -414,7 +414,7 @@ class ProductConfigSession(models.Model):
             value_ids = self.value_ids.ids
 
         if custom_vals is None:
-            custom_vals = {}
+            custom_vals = self._get_custom_vals_dict()
 
         product_tmpl = self.product_tmpl_id
 
@@ -840,20 +840,26 @@ class ProductConfigSession(models.Model):
             value_ids = self.value_ids.ids
 
         if custom_vals is None:
-            custom_vals = {}
+            custom_vals = self._get_custom_vals_dict()
+
+        session_custom_values = self.custom_value_ids.filtered(
+            lambda cv: cv.attribute_id.id in custom_vals.keys()
+        )
+        custom_prices = session_custom_values.mapped("price")
+
+        price_extra = sum(custom_prices)
 
         product_tmpl = self.product_tmpl_id
         self = self.with_context(active_id=product_tmpl.id)
 
         value_ids = self.flatten_val_ids(value_ids)
 
-        price_extra = 0.0
         attr_val_obj = self.env["product.attribute.value"]
         av_ids = attr_val_obj.browse(value_ids)
         extra_prices = attr_val_obj.get_attribute_value_extra_prices(
             product_tmpl_id=product_tmpl.id, pt_attr_value_ids=av_ids
         )
-        price_extra = sum(extra_prices.values())
+        price_extra += sum(extra_prices.values())
         return product_tmpl.list_price + price_extra
 
     def _get_config_image(self, value_ids=None, custom_vals=None, size=None):
@@ -1629,6 +1635,43 @@ class ProductConfigSessionCustomValue(models.Model):
         column2="attachment_id",
         string="Attachments",
     )
+    price = fields.Float(
+        compute="_compute_price",
+        help="Price computed using attribute's 'Extra price formula'.",
+    )
+
+    def _eval_price_formula_variables_dict(self):
+        """Variables described in `product.attribute.configurator_extra_price_formula`."""
+        self.ensure_one()
+        return {
+            "attribute": self.attribute_id,
+            "config_session": self.cfg_session_id,
+            "custom_value": self.eval(),
+            "product": self.cfg_session_id.product_id,
+        }
+
+    def _eval_price_formula(self):
+        self.ensure_one()
+        price_formula = self.attribute_id.configurator_extra_price_formula
+        if price_formula:
+            variables_dict = self._eval_price_formula_variables_dict()
+            safe_eval(
+                price_formula,
+                globals_dict=variables_dict,
+                mode="exec",
+                nocopy=True,
+            )
+            price = variables_dict.get("price", 0)
+        else:
+            price = 0
+        return price
+
+    @api.depends(
+        "value",
+    )
+    def _compute_price(self):
+        for custom_value in self:
+            custom_value.price = custom_value._eval_price_formula()
 
     def eval(self):
         """Return custom value evaluated using the related custom field type"""

--- a/product_configurator/tests/__init__.py
+++ b/product_configurator/tests/__init__.py
@@ -4,3 +4,4 @@ from . import test_product
 from . import test_product_attribute
 from . import test_product_config
 from . import test_wizard
+from . import test_custom_attribute_price

--- a/product_configurator/tests/test_custom_attribute_price.py
+++ b/product_configurator/tests/test_custom_attribute_price.py
@@ -1,0 +1,112 @@
+#  Copyright 2024 Simone Rubino - Aion Tech
+#  License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.fields import first
+from odoo.tests import Form, TransactionCase
+from odoo.tools.safe_eval import safe_eval
+
+
+class TestCustomAttributePrice(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # The product attribute view only shows configuration fields
+        # (such as `val_custom`)
+        # when called with a specific context
+        # that is set by this action
+        configuration_attributes_action = cls.env.ref(
+            "product_configurator.action_attributes_view"
+        )
+        action_eval_context = configuration_attributes_action._get_eval_context()
+        configuration_attribute_context = safe_eval(
+            configuration_attributes_action.context, globals_dict=action_eval_context
+        )
+        configuration_attribute_model = cls.env["product.attribute"].with_context(
+            **configuration_attribute_context
+        )
+
+        custom_attribute_form = Form(configuration_attribute_model)
+        custom_attribute_form.name = "Test custom attribute"
+        custom_attribute_form.val_custom = True
+        cls.custom_attribute = custom_attribute_form.save()
+        cls.custom_attribute_value = cls.env.ref(
+            "product_configurator.custom_attribute_value"
+        )
+
+        regular_attribute_form = Form(configuration_attribute_model)
+        regular_attribute_form.name = "Test custom attribute"
+        regular_attribute_form.val_custom = False
+        with regular_attribute_form.value_ids.new() as value:
+            value.name = "Test value 1"
+        cls.regular_attribute = regular_attribute_form.save()
+
+        product_template_form = Form(cls.env["product.template"])
+        product_template_form.name = "Test configurable product"
+        with product_template_form.attribute_line_ids.new() as custom_line:
+            custom_line.attribute_id = cls.custom_attribute
+        with product_template_form.attribute_line_ids.new() as regular_line:
+            regular_line.attribute_id = cls.regular_attribute
+            regular_line.value_ids.add(first(cls.regular_attribute.value_ids))
+        product_template = product_template_form.save()
+        product_template.config_ok = True
+        cls.product_template = product_template
+
+    def test_integer_multiplier_formula(self):
+        """The custom attribute has a formula `custom_value` * `multiplier`,
+        check that the configuration's price is computed correctly.
+        """
+        # Arrange
+        regular_attribute = self.regular_attribute
+
+        multiplier = 5
+        custom_value = 3
+        custom_attribute = self.custom_attribute
+        custom_attribute.custom_type = "integer"
+        custom_attribute.configurator_extra_price_formula = (
+            "price = custom_value * %s" % multiplier
+        )
+        custom_attribute_value = self.custom_attribute_value
+
+        product_template = self.product_template
+
+        # Act: configure the product
+        wizard_action = product_template.configure_product()
+        wizard = self.env[wizard_action["res_model"]].browse(wizard_action["res_id"])
+        self.assertEqual(wizard.state, "select")
+        wizard.action_next_step()
+        self.assertEqual(wizard.state, "configure")
+        fields_prefixes = wizard._prefixes
+        field_prefix = fields_prefixes.get("field_prefix")
+        custom_field_prefix = fields_prefixes.get("custom_field_prefix")
+        wizard.write(
+            {
+                field_prefix
+                + str(regular_attribute.id): first(regular_attribute.value_ids).id,
+                field_prefix + str(custom_attribute.id): custom_attribute_value.id,
+                custom_field_prefix + str(custom_attribute.id): custom_value,
+            }
+        )
+        wizard.action_config_done()
+
+        # Assert
+        configured_session = wizard.config_session_id
+        configured_custom_value = configured_session.custom_value_ids
+        self.assertEqual(configured_custom_value.price, custom_value * multiplier)
+
+        expected_configuration_price = (
+            product_template.list_price + configured_custom_value.price
+        )
+        self.assertEqual(configured_session.price, expected_configuration_price)
+
+        # Act: change the custom value
+        new_custom_value = 2
+        configured_custom_value.value = "%s" % new_custom_value
+
+        # Assert: the price has changed
+        new_expected_custom_price = new_custom_value * multiplier
+        self.assertEqual(configured_custom_value.price, new_expected_custom_price)
+
+        new_expected_configuration_price = (
+            product_template.list_price + configured_custom_value.price
+        )
+        self.assertEqual(configured_session.price, new_expected_configuration_price)

--- a/product_configurator/tests/test_wizard.py
+++ b/product_configurator/tests/test_wizard.py
@@ -342,10 +342,10 @@ class ConfigurationWizard(ProductConfiguratorTestCases):
 
     def test_13_fields_view_get(self):
         product_config_wizard = self._check_wizard_nxt_step()
-        product_config_wizard.fields_view_get()
+        product_config_wizard.get_view()
         product_config_wizard.with_context(
             wizard_id=product_config_wizard.id
-        ).fields_view_get()
+        ).get_view()
         # custom value
         # custom value
         self.attr_line_fuel.custom = True
@@ -408,7 +408,7 @@ class ConfigurationWizard(ProductConfiguratorTestCases):
         product_config_wizard_1.action_next_step()
         product_config_wizard_1.with_context(
             wizard_id=product_config_wizard_1.id
-        ).fields_view_get()
+        ).get_view()
 
     def test_14_unlink(self):
         product_config_wizard = self._check_wizard_nxt_step()

--- a/product_configurator/views/product_attribute_view.xml
+++ b/product_configurator/views/product_attribute_view.xml
@@ -82,6 +82,9 @@
                         <group>
                             <field name="search_ok" />
                         </group>
+                        <group>
+                            <field name="configurator_extra_price_formula" />
+                        </group>
                     </group>
                 </page>
             </xpath>

--- a/product_configurator/views/product_config_view.xml
+++ b/product_configurator/views/product_config_view.xml
@@ -176,6 +176,7 @@
                                 <tree editable="bottom">
                                     <field name="attribute_id" />
                                     <field name="value" />
+                                    <field name="price" />
                                     <field
                                         name="attachment_ids"
                                         widget="many2many_tags"

--- a/product_configurator/wizard/product_configurator.py
+++ b/product_configurator/wizard/product_configurator.py
@@ -186,7 +186,7 @@ class ProductConfigurator(models.TransientModel):
                     continue
         return domains
 
-    def get_onchange_vals(self, cfg_val_ids, config_session_id=None):
+    def get_onchange_vals(self, cfg_val_ids, config_session_id=None, custom_vals=None):
         """Onchange hook to add / modify returned values by onchange method"""
         if not config_session_id:
             config_session_id = self.config_session_id
@@ -194,9 +194,18 @@ class ProductConfigurator(models.TransientModel):
         # Remove None from cfg_val_ids if exist
         cfg_val_ids = [val for val in cfg_val_ids if val]
 
-        product_img = config_session_id.get_config_image(cfg_val_ids)
-        price = config_session_id.get_cfg_price(cfg_val_ids)
-        weight = config_session_id.get_cfg_weight(value_ids=cfg_val_ids)
+        product_img = config_session_id.get_config_image(
+            cfg_val_ids,
+            custom_vals=custom_vals,
+        )
+        price = config_session_id.get_cfg_price(
+            cfg_val_ids,
+            custom_vals=custom_vals,
+        )
+        weight = config_session_id.get_cfg_weight(
+            value_ids=cfg_val_ids,
+            custom_vals=custom_vals,
+        )
 
         return {
             "product_img": product_img,
@@ -212,6 +221,7 @@ class ProductConfigurator(models.TransientModel):
         cfg_val_ids=None,
         product_tmpl_id=None,
         config_session_id=None,
+        custom_vals=None,
     ):
         """Generate a dictionary to return new values via onchange method.
         Domains hold the values available, this method enforces these values
@@ -241,13 +251,39 @@ class ProductConfigurator(models.TransientModel):
                 vals[k] = v
         final_cfg_val_ids = list(dynamic_fields.values())
 
-        vals.update(self.get_onchange_vals(final_cfg_val_ids, config_session_id))
+        changed_values = self.get_onchange_vals(
+            final_cfg_val_ids,
+            config_session_id=config_session_id,
+            custom_vals=custom_vals,
+        )
+        vals.update(changed_values)
         # To solve the Multi selection problem removing extra []
         if "value_ids" in vals:
             val_ids = vals["value_ids"][0]
             vals["value_ids"] = [[val_ids[0], val_ids[1], tools.flatten(val_ids[2])]]
 
         return vals
+
+    def _extract_onchange_custom_vals(self, values):
+        """Extract custom values from onchange values `values`.
+
+        Custom values are returned as per the structure
+        defined in product.config.session._get_custom_vals_dict.
+        """
+        custom_field_prefix = self._prefixes.get("custom_field_prefix")
+        custom_vals = {}
+        for field_name, field_value in values.items():
+            if field_name.startswith(custom_field_prefix):
+                attribute_id = int(field_name[len(custom_field_prefix) :])
+                # Create a temporary custom value to be able to `eval` the view's value.
+                temp_custom_value = self.env["product.config.session.custom.value"].new(
+                    {
+                        "attribute_id": attribute_id,
+                        "value": field_value,
+                    }
+                )
+                custom_vals[attribute_id] = temp_custom_value.eval()
+        return custom_vals
 
     def apply_onchange_values(self, values, field_name, field_onchange):
         """Called from web-controller
@@ -331,11 +367,14 @@ class ProductConfigurator(models.TransientModel):
         domains = self.get_onchange_domains(
             values, cfg_val_ids, product_tmpl_id, config_session_id
         )
+        custom_vals = self._extract_onchange_custom_vals(values)
+
         vals = self.get_form_vals(
             dynamic_fields=dynamic_fields,
             domains=domains,
             product_tmpl_id=product_tmpl_id,
             config_session_id=config_session_id,
+            custom_vals=custom_vals,
         )
 
         return {"value": vals, "domain": domains}
@@ -762,7 +801,11 @@ class ProductConfigurator(models.TransientModel):
                     attrs["readonly"].insert(0, "|")
 
                 node = etree.Element(
-                    "field", name=custom_field, attrs=str(attrs), widget=widget
+                    "field",
+                    name=custom_field,
+                    attrs=str(attrs),
+                    widget=widget,
+                    on_change="1",
                 )
                 self.setup_modifiers(node)
                 xml_dynamic_form.append(node)


### PR DESCRIPTION
Allow to have a price for custom attributes that depends on the custom value.

Since there is only one "Custom" attribute value that is used for all the custom attributes, one way to have different prices is to let the user write a formula that can change depending on the product (and other values, for instance the value of other attributes).