### PR TITLE
[16.0][IMP] product_configurator: cleanup (pre-commit + reactivate tests)

### DIFF
--- a/product_configurator/models/ir_ui_view.py
+++ b/product_configurator/models/ir_ui_view.py
@@ -8,5 +8,4 @@ class View(models.Model):
         special = node.get("special")
         if special and special == "no_save":
             return
-        else:
-            return super()._validate_tag_button(node, name_manager, node_info)
+        return super()._validate_tag_button(node, name_manager, node_info)

--- a/product_configurator/models/product.py
+++ b/product_configurator/models/product.py
@@ -19,7 +19,7 @@ class ProductTemplate(models.Model):
         1 as many views and methods trigger only when a template has at least
         one variant attached. Since we create them from the template we should
         have access to them always"""
-        result = super(ProductTemplate, self)._compute_product_variant_count()
+        result = super()._compute_product_variant_count()
         for product_tmpl in self:
             config_ok = product_tmpl.config_ok
             variant_count = product_tmpl.product_variant_count
@@ -159,7 +159,7 @@ class ProductTemplate(models.Model):
                 value_ids=default_val_ids, product_tmpl_id=self.id, final=False
             )
         except ValidationError as exc:
-            raise exc
+            raise ValidationError(exc.args[0]) from exc
         except Exception as exc:
             raise ValidationError(
                 _("Default values provided generate an invalid configuration")
@@ -177,7 +177,7 @@ class ProductTemplate(models.Model):
                         "generate an invalid configuration.\
                       \n%s"
                     )
-                    % (exc.args[0])
+                    % (exc.name)
                 ) from exc
 
     def toggle_config(self):
@@ -205,7 +205,7 @@ class ProductTemplate(models.Model):
             )
             if variant_unlink:
                 self -= config_template
-        res = super(ProductTemplate, self).unlink()
+        res = super().unlink()
         return res
 
     def copy(self, default=None):
@@ -214,7 +214,7 @@ class ProductTemplate(models.Model):
         if not default:
             default = {}
         self = self.with_context(check_constraint=False)
-        res = super(ProductTemplate, self).copy(default=default)
+        res = super().copy(default=default)
 
         # Attribute lines
         attribute_line_dict = {}
@@ -325,7 +325,7 @@ class ProductTemplate(models.Model):
             config_ok = vals.get("config_ok", False)
             if config_ok:
                 self.check_config_user_access()
-        return super(ProductTemplate, self).create(vals_list)
+        return super().create(vals_list)
 
     def write(self, vals):
         """Patch for check access rights of user(configurable products)"""
@@ -334,7 +334,7 @@ class ProductTemplate(models.Model):
         if change_config_ok or configurable_templates:
             self[:1].check_config_user_access()
 
-        return super(ProductTemplate, self).write(vals)
+        return super().write(vals)
 
     @api.constrains("config_line_ids")
     def _check_config_line_domain(self):
@@ -537,7 +537,7 @@ class ProductProduct(models.Model):
             self.env["product.product"].check_config_user_access(mode="delete")
         ctx = dict(self.env.context, unlink_from_variant=True)
         self.env.context = ctx
-        return super(ProductProduct, self).unlink()
+        return super().unlink()
 
     @api.model_create_multi
     def create(self, vals_list):
@@ -546,7 +546,7 @@ class ProductProduct(models.Model):
             config_ok = vals.get("config_ok", False)
             if config_ok:
                 self.check_config_user_access(mode="create")
-        return super(ProductProduct, self).create(vals_list)
+        return super().create(vals_list)
 
     def write(self, vals):
         """Patch for check access rights of user(configurable products)"""
@@ -555,7 +555,7 @@ class ProductProduct(models.Model):
         if change_config_ok or configurable_products:
             self[:1].check_config_user_access(mode="write")
 
-        return super(ProductProduct, self).write(vals)
+        return super().write(vals)
 
     def _compute_product_price_extra(self):
         standard_products = self.filtered(lambda product: not product.config_ok)

--- a/product_configurator/models/product.py
+++ b/product_configurator/models/product.py
@@ -396,7 +396,7 @@ class ProductProduct(models.Model):
             duplicates = config_session_obj.search_variant(
                 product_tmpl_id=product.product_tmpl_id,
                 value_ids=ptav_ids.ids,
-            ).filtered(lambda p: p.id != product.id)
+            ).filtered(lambda p, product=product: p.id != product.id)
 
             if duplicates:
                 raise ValidationError(

--- a/product_configurator/models/product_attribute.py
+++ b/product_configurator/models/product_attribute.py
@@ -130,8 +130,9 @@ class ProductAttribute(models.Model):
             elif maxv and val > maxv:
                 raise ValidationError(
                     _(
-                        "Selected custom value '%(name)s' must be lower than %(max_value)s",
-                        **{"name": self.name, "max_val": self.max_val + 1},
+                        "Selected custom value '%(name)s' "
+                        "must be lower than %(max_value)s",
+                        **{"name": self.name, "max_value": self.max_val + 1},
                     )
                 )
 
@@ -302,8 +303,8 @@ class ProductAttributeValue(models.Model):
         return extra_prices
 
     def name_get(self):
-        res = super(ProductAttributeValue, self).name_get()
-        if not self._context.get("show_price_extra"):
+        res = super().name_get()
+        if not self.env.context.get("show_price_extra"):
             return res
         product_template_id = self.env.context.get("active_id", False)
 
@@ -318,8 +319,7 @@ class ProductAttributeValue(models.Model):
             if price_extra:
                 val = (
                     val[0],
-                    "%s ( +%s )"
-                    % (
+                    "{} ( +{} )".format(
                         val[1],
                         ("{0:,.%sf}" % (price_precision)).format(price_extra),
                     ),

--- a/product_configurator/models/product_attribute.py
+++ b/product_configurator/models/product_attribute.py
@@ -256,7 +256,7 @@ class ProductAttributeValue(models.Model):
         if not default:
             default = {}
         default.update({"name": self.name + " (copy)"})
-        product = super(ProductAttributeValue, self).copy(default)
+        product = super().copy(default)
         return product
 
     active = fields.Boolean(
@@ -367,9 +367,7 @@ class ProductAttributeValue(models.Model):
             if attr_restrict_ids:
                 new_args.append(("attribute_id", "not in", attr_restrict_ids))
             args = new_args
-        res = super(ProductAttributeValue, self).name_search(
-            name=name, args=args, operator=operator, limit=limit
-        )
+        res = super().name_search(name=name, args=args, operator=operator, limit=limit)
         return res
 
     # TODO: Prevent unlinking custom options by overriding unlink
@@ -402,7 +400,7 @@ class ProductAttributeValueLine(models.Model):
     )
     value_id = fields.Many2one(
         comodel_name="product.attribute.value",
-        required="True",
+        required=True,
         string="Attribute Value",
     )
     attribute_id = fields.Many2one(

--- a/product_configurator/tests/__init__.py
+++ b/product_configurator/tests/__init__.py
@@ -3,5 +3,5 @@ from . import test_configuration_rules
 from . import test_product
 
 # from . import test_product_attribute
-# from . import test_product_config
+from . import test_product_config
 from . import test_wizard

--- a/product_configurator/tests/__init__.py
+++ b/product_configurator/tests/__init__.py
@@ -4,4 +4,4 @@ from . import test_product
 
 # from . import test_product_attribute
 # from . import test_product_config
-# from . import test_wizard
+from . import test_wizard

--- a/product_configurator/tests/__init__.py
+++ b/product_configurator/tests/__init__.py
@@ -1,4 +1,4 @@
-# from . import test_create
+from . import test_create
 from . import test_configuration_rules
 from . import test_product
 from . import test_product_attribute

--- a/product_configurator/tests/__init__.py
+++ b/product_configurator/tests/__init__.py
@@ -1,7 +1,6 @@
 # from . import test_create
 from . import test_configuration_rules
 from . import test_product
-
-# from . import test_product_attribute
+from . import test_product_attribute
 from . import test_product_config
 from . import test_wizard

--- a/product_configurator/tests/common.py
+++ b/product_configurator/tests/common.py
@@ -92,11 +92,10 @@ class ProductConfiguratorTestCases(BaseCommon):
         )
         product_config_wizard.action_next_step()
         product_config_wizard.action_next_step()
-        product_config_wizard.write(
-            {
-                f"__attribute_{self.attr_model_line.id}": self.value_model_sport_line.id,
-            }
-        )
+        vals = {
+            f"__attribute_{self.attr_model_line.id}": self.value_model_sport_line.id,
+        }
+        product_config_wizard.write(vals)
         product_config_wizard.action_next_step()
         product_config_wizard.write(
             {

--- a/product_configurator/tests/common.py
+++ b/product_configurator/tests/common.py
@@ -57,57 +57,58 @@ class ProductConfiguratorTestCases(BaseCommon):
             "product_configurator.product_attribute_value_sunroof"
         )
 
-    def _configure_product_nxt_step(self):
-        product_config_wizard = self.ProductConfWizard.create(
+    @classmethod
+    def _configure_product_nxt_step(cls):
+        product_config_wizard = cls.ProductConfWizard.create(
             {
-                "product_tmpl_id": self.config_product.id,
+                "product_tmpl_id": cls.config_product.id,
             }
         )
         product_config_wizard.action_next_step()
         product_config_wizard.write(
             {
-                f"__attribute_{self.attr_fuel.id}": self.value_gasoline.id,
-                f"__attribute_{self.attr_engine.id}": self.value_218i.id,
+                f"__attribute_{cls.attr_fuel.id}": cls.value_gasoline.id,
+                f"__attribute_{cls.attr_engine.id}": cls.value_218i.id,
             }
         )
         product_config_wizard.action_next_step()
         product_config_wizard.write(
             {
-                f"__attribute_{self.attr_color.id}": self.value_red.id,
-                f"__attribute_{self.attr_rims.id}": self.value_rims_378.id,
+                f"__attribute_{cls.attr_color.id}": cls.value_red.id,
+                f"__attribute_{cls.attr_rims.id}": cls.value_rims_378.id,
             }
         )
         product_config_wizard.action_next_step()
         product_config_wizard.write(
             {
-                f"__attribute_{self.attr_model_line.id}": self.value_sport_line.id,
+                f"__attribute_{cls.attr_model_line.id}": cls.value_sport_line.id,
             }
         )
         product_config_wizard.action_previous_step()
         product_config_wizard.action_previous_step()
         product_config_wizard.write(
             {
-                f"__attribute_{self.attr_engine.id}": self.value_220i.id,
+                f"__attribute_{cls.attr_engine.id}": cls.value_220i.id,
             }
         )
         product_config_wizard.action_next_step()
         product_config_wizard.action_next_step()
         vals = {
-            f"__attribute_{self.attr_model_line.id}": self.value_model_sport_line.id,
+            f"__attribute_{cls.attr_model_line.id}": cls.value_model_sport_line.id,
         }
         product_config_wizard.write(vals)
         product_config_wizard.action_next_step()
         product_config_wizard.write(
             {
-                f"__attribute_{self.attr_tapistry.id}": self.value_tapistry.id,
+                f"__attribute_{cls.attr_tapistry.id}": cls.value_tapistry.id,
             }
         )
         product_config_wizard.action_next_step()
         product_config_wizard.write(
             {
-                f"__attribute_{self.attr_transmission.id}": self.value_transmission.id,
-                f"__attribute_{self.attr_options.id}": [
-                    [6, 0, [self.value_options_2.id]]
+                f"__attribute_{cls.attr_transmission.id}": cls.value_transmission.id,
+                f"__attribute_{cls.attr_options.id}": [
+                    [6, 0, [cls.value_options_2.id]]
                 ],
             }
         )

--- a/product_configurator/tests/common.py
+++ b/product_configurator/tests/common.py
@@ -8,7 +8,6 @@ class ProductConfiguratorTestCases(BaseCommon):
         cls.ProductConfWizard = cls.env["product.configurator"]
         cls.config_product = cls.env.ref("product_configurator.bmw_2_series")
         cls.product_category = cls.env.ref("product.product_category_5")
-
         # attributes
         cls.attr_fuel = cls.env.ref("product_configurator.product_attribute_fuel")
         cls.attr_engine = cls.env.ref("product_configurator.product_attribute_engine")
@@ -67,54 +66,48 @@ class ProductConfiguratorTestCases(BaseCommon):
         product_config_wizard.action_next_step()
         product_config_wizard.write(
             {
-                "__attribute_{}".format(self.attr_fuel.id): self.value_gasoline.id,
-                "__attribute_{}".format(self.attr_engine.id): self.value_218i.id,
+                f"__attribute_{self.attr_fuel.id}": self.value_gasoline.id,
+                f"__attribute_{self.attr_engine.id}": self.value_218i.id,
             }
         )
         product_config_wizard.action_next_step()
         product_config_wizard.write(
             {
-                "__attribute_{}".format(self.attr_color.id): self.value_red.id,
-                "__attribute_{}".format(self.attr_rims.id): self.value_rims_378.id,
+                f"__attribute_{self.attr_color.id}": self.value_red.id,
+                f"__attribute_{self.attr_rims.id}": self.value_rims_378.id,
             }
         )
         product_config_wizard.action_next_step()
         product_config_wizard.write(
             {
-                "__attribute_{}".format(
-                    self.attr_model_line.id
-                ): self.value_sport_line.id,
+                f"__attribute_{self.attr_model_line.id}": self.value_sport_line.id,
             }
         )
         product_config_wizard.action_previous_step()
         product_config_wizard.action_previous_step()
         product_config_wizard.write(
             {
-                "__attribute_{}".format(self.attr_engine.id): self.value_220i.id,
+                f"__attribute_{self.attr_engine.id}": self.value_220i.id,
             }
         )
         product_config_wizard.action_next_step()
         product_config_wizard.action_next_step()
         product_config_wizard.write(
             {
-                "__attribute_{}".format(
-                    self.attr_model_line.id
-                ): self.value_model_sport_line.id,
+                f"__attribute_{self.attr_model_line.id}": self.value_model_sport_line.id,
             }
         )
         product_config_wizard.action_next_step()
         product_config_wizard.write(
             {
-                "__attribute_{}".format(self.attr_tapistry.id): self.value_tapistry.id,
+                f"__attribute_{self.attr_tapistry.id}": self.value_tapistry.id,
             }
         )
         product_config_wizard.action_next_step()
         product_config_wizard.write(
             {
-                "__attribute_{}".format(
-                    self.attr_transmission.id
-                ): self.value_transmission.id,
-                "__attribute_{}".format(self.attr_options.id): [
+                f"__attribute_{self.attr_transmission.id}": self.value_transmission.id,
+                f"__attribute_{self.attr_options.id}": [
                     [6, 0, [self.value_options_2.id]]
                 ],
             }

--- a/product_configurator/tests/test_configuration_rules.py
+++ b/product_configurator/tests/test_configuration_rules.py
@@ -100,7 +100,7 @@ class ConfigurationRules(TransactionCase):
         cls.product_template = product_template
 
     def setUp(self):
-        super(ConfigurationRules, self).setUp()
+        super().setUp()
 
         self.cfg_tmpl = self.env.ref("product_configurator.bmw_2_series")
         self.cfg_session = self.env["product.config.session"].create(
@@ -150,7 +150,6 @@ class ConfigurationRules(TransactionCase):
         self.assertTrue(validation, "Valid configuration failed validation")
 
     def test_invalid_configuration(self):
-
         conf = [
             "diesel",
             "228i",

--- a/product_configurator/tests/test_create.py
+++ b/product_configurator/tests/test_create.py
@@ -3,7 +3,7 @@ from odoo.tests.common import TransactionCase
 
 class ConfigurationCreate(TransactionCase):
     def setUp(self):
-        super(ConfigurationCreate, self).setUp()
+        super().setUp()
 
         self.ProductConfWizard = self.env["product.configurator"]
         self.config_product = self.env.ref("product_configurator.bmw_2_series")
@@ -115,54 +115,48 @@ class ConfigurationCreate(TransactionCase):
         product_config_wizard.action_next_step()
         product_config_wizard.write(
             {
-                "__attribute_{}".format(self.attr_fuel.id): self.value_gasoline.id,
-                "__attribute_{}".format(self.attr_engine.id): self.value_218i.id,
+                f"__attribute_{self.attr_fuel.id}": self.value_gasoline.id,
+                f"__attribute_{self.attr_engine.id}": self.value_218i.id,
             }
         )
         product_config_wizard.action_next_step()
         product_config_wizard.write(
             {
-                "__attribute_{}".format(self.attr_color.id): self.value_red.id,
-                "__attribute_{}".format(self.attr_rims.id): self.value_rims_378.id,
+                f"__attribute_{self.attr_color.id}": self.value_red.id,
+                f"__attribute_{self.attr_rims.id}": self.value_rims_378.id,
             }
         )
         product_config_wizard.action_next_step()
         product_config_wizard.write(
             {
-                "__attribute_{}".format(
-                    self.attr_model_line.id
-                ): self.value_sport_line.id,
+                f"__attribute_{self.attr_model_line.id}": self.value_sport_line.id,
             }
         )
         product_config_wizard.action_previous_step()
         product_config_wizard.action_previous_step()
         product_config_wizard.write(
             {
-                "__attribute_{}".format(self.attr_engine.id): self.value_220i.id,
+                f"__attribute_{self.attr_engine.id}": self.value_220i.id,
             }
         )
         product_config_wizard.action_next_step()
         product_config_wizard.action_next_step()
         product_config_wizard.write(
             {
-                "__attribute_{}".format(
-                    self.attr_model_line.id
-                ): self.value_model_sport_line.id,
+                f"__attribute_{self.attr_model_line.id}": self.value_model_sport_line.id,
             }
         )
         product_config_wizard.action_next_step()
         product_config_wizard.write(
             {
-                "__attribute_{}".format(self.attr_tapistry.id): self.value_tapistry.id,
+                f"__attribute_{self.attr_tapistry.id}": self.value_tapistry.id,
             }
         )
         product_config_wizard.action_next_step()
         product_config_wizard.write(
             {
-                "__attribute_{}".format(
-                    self.attr_transmission.id
-                ): self.value_transmission.id,
-                "__attribute_{}".format(self.attr_options.id): [
+                f"__attribute_{self.attr_transmission.id}": self.value_transmission.id,
+                f"__attribute_{self.attr_options.id}": [
                     [6, 0, [self.value_options_1.id, self.value_options_2.id]]
                 ],
             }

--- a/product_configurator/tests/test_create.py
+++ b/product_configurator/tests/test_create.py
@@ -1,64 +1,60 @@
-from odoo.tests.common import TransactionCase
+from odoo.addons.base.tests.common import BaseCommon
 
 
-class ConfigurationCreate(TransactionCase):
-    def setUp(self):
-        super().setUp()
-
-        self.ProductConfWizard = self.env["product.configurator"]
-        self.config_product = self.env.ref("product_configurator.bmw_2_series")
-        self.product_category = self.env.ref("product.product_category_5")
+class ConfigurationCreate(BaseCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.ProductConfWizard = cls.env["product.configurator"]
+        cls.config_product = cls.env.ref("product_configurator.bmw_2_series")
+        cls.product_category = cls.env.ref("product.product_category_5")
 
         # attributes
-        self.attr_fuel = self.env.ref("product_configurator.product_attribute_fuel")
-        self.attr_engine = self.env.ref("product_configurator.product_attribute_engine")
-        self.attr_color = self.env.ref("product_configurator.product_attribute_color")
-        self.attr_rims = self.env.ref("product_configurator.product_attribute_rims")
-        self.attr_model_line = self.env.ref(
+        cls.attr_fuel = cls.env.ref("product_configurator.product_attribute_fuel")
+        cls.attr_engine = cls.env.ref("product_configurator.product_attribute_engine")
+        cls.attr_color = cls.env.ref("product_configurator.product_attribute_color")
+        cls.attr_rims = cls.env.ref("product_configurator.product_attribute_rims")
+        cls.attr_model_line = cls.env.ref(
             "product_configurator.product_attribute_model_line"
         )
-        self.attr_tapistry = self.env.ref(
+        cls.attr_tapistry = cls.env.ref(
             "product_configurator.product_attribute_tapistry"
         )
-        self.attr_transmission = self.env.ref(
+        cls.attr_transmission = cls.env.ref(
             "product_configurator.product_attribute_transmission"
         )
-        self.attr_options = self.env.ref(
-            "product_configurator.product_attribute_options"
-        )
+        cls.attr_options = cls.env.ref("product_configurator.product_attribute_options")
 
         # values
-        self.value_gasoline = self.env.ref(
+        cls.value_gasoline = cls.env.ref(
             "product_configurator.product_attribute_value_gasoline"
         )
-        self.value_218i = self.env.ref(
+        cls.value_218i = cls.env.ref(
             "product_configurator.product_attribute_value_218i"
         )
-        self.value_220i = self.env.ref(
+        cls.value_220i = cls.env.ref(
             "product_configurator.product_attribute_value_220i"
         )
-        self.value_red = self.env.ref(
-            "product_configurator.product_attribute_value_red"
-        )
-        self.value_rims_378 = self.env.ref(
+        cls.value_red = cls.env.ref("product_configurator.product_attribute_value_red")
+        cls.value_rims_378 = cls.env.ref(
             "product_configurator.product_attribute_value_rims_378"
         )
-        self.value_sport_line = self.env.ref(
+        cls.value_sport_line = cls.env.ref(
             "product_configurator.product_attribute_value_sport_line"
         )
-        self.value_model_sport_line = self.env.ref(
+        cls.value_model_sport_line = cls.env.ref(
             "product_configurator.product_attribute_value_model_sport_line"
         )
-        self.value_tapistry = self.env.ref(
+        cls.value_tapistry = cls.env.ref(
             "product_configurator.product_attribute_value_tapistry" + "_oyster_black"
         )
-        self.value_transmission = self.env.ref(
+        cls.value_transmission = cls.env.ref(
             "product_configurator.product_attribute_value_steptronic"
         )
-        self.value_options_1 = self.env.ref(
+        cls.value_options_1 = cls.env.ref(
             "product_configurator.product_attribute_value_smoker_package"
         )
-        self.value_options_2 = self.env.ref(
+        cls.value_options_2 = cls.env.ref(
             "product_configurator.product_attribute_value_sunroof"
         )
 
@@ -161,7 +157,7 @@ class ConfigurationCreate(TransactionCase):
             }
         )
         product_config_wizard.action_next_step()
-        value_ids = (
+        value_ids = (  # noqa
             self.value_gasoline
             + self.value_220i
             + self.value_red
@@ -172,11 +168,17 @@ class ConfigurationCreate(TransactionCase):
             + self.value_options_1
             + self.value_options_2
         )
-        new_variant = self.config_product.product_variant_ids.filtered(
-            lambda variant: variant.attribute_value_ids == value_ids
-        )
-        self.assertNotEqual(
-            new_variant.id,
-            False,
-            "Variant not generated at the end of the configuration process",
-        )
+        # FIXME: broken as
+        # """
+        # AttributeError: 'product.product' object
+        # has no attribute 'attribute_value_ids'.
+        # Did you mean: 'attribute_line_ids'?
+        # """
+        # new_variant = self.config_product.product_variant_ids.filtered(
+        #     lambda variant: variant.attribute_value_ids == value_ids
+        # )
+        # self.assertNotEqual(
+        #     new_variant.id,
+        #     False,
+        #     "Variant not generated at the end of the configuration process",
+        # )

--- a/product_configurator/tests/test_create.py
+++ b/product_configurator/tests/test_create.py
@@ -141,11 +141,10 @@ class ConfigurationCreate(TransactionCase):
         )
         product_config_wizard.action_next_step()
         product_config_wizard.action_next_step()
-        product_config_wizard.write(
-            {
-                f"__attribute_{self.attr_model_line.id}": self.value_model_sport_line.id,
-            }
-        )
+        vals = {
+            f"__attribute_{self.attr_model_line.id}": self.value_model_sport_line.id,
+        }
+        product_config_wizard.write(vals)
         product_config_wizard.action_next_step()
         product_config_wizard.write(
             {

--- a/product_configurator/tests/test_product.py
+++ b/product_configurator/tests/test_product.py
@@ -2,6 +2,10 @@ from odoo.exceptions import ValidationError
 
 from ..tests.common import ProductConfiguratorTestCases
 
+# FIXME: many tests here do not have any assertions.
+# They simply run something and expect it to not raise an exception.
+# This is not a good practice. Tests should have assertions.
+
 
 class TestProduct(ProductConfiguratorTestCases):
     @classmethod

--- a/product_configurator/tests/test_product.py
+++ b/product_configurator/tests/test_product.py
@@ -377,22 +377,19 @@ class TestProduct(ProductConfiguratorTestCases):
 
     def test_11_compute_product_weight_extra(self):
         product_id = self.env.ref("product.product_delivery_01")
-        product_template_attribute_value_ids = self.env.ref(
+        product_template_attr_value_ids = self.env.ref(
             "product.product_4_attribute_1_value_2"
         )
-        product_template_attribute_value_ids.write(
+        product_template_attr_value_ids.write(
             {
                 "weight_extra": 50.0,
             }
         )
         product_id._compute_product_weight_extra()
-        product_id.write(
-            {
-                "product_template_attribute_value_ids": product_template_attribute_value_ids
-            }
-        )
+        vals = {"product_template_attribute_value_ids": product_template_attr_value_ids}
+        product_id.write(vals)
         self.assertEqual(
-            product_template_attribute_value_ids.weight_extra,
+            product_template_attr_value_ids.weight_extra,
             50.0,
             product_id.weight_extra,
         )

--- a/product_configurator/tests/test_product.py
+++ b/product_configurator/tests/test_product.py
@@ -143,9 +143,9 @@ class TestProduct(ProductConfiguratorTestCases):
         product_config_wizard.action_next_step()
         product_config_wizard.write(
             {
-                "__attribute_{}".format(self.attr_fuel.id): self.value_gasoline.id,
-                "__attribute_{}".format(self.attr_engine.id): self.value_218i.id,
-                "__attribute_{}".format(self.attr_color.id): self.value_red.id,
+                f"__attribute_{self.attr_fuel.id}": self.value_gasoline.id,
+                f"__attribute_{self.attr_engine.id}": self.value_218i.id,
+                f"__attribute_{self.attr_color.id}": self.value_red.id,
             }
         )
         product_config_wizard.action_next_step()
@@ -179,9 +179,9 @@ class TestProduct(ProductConfiguratorTestCases):
         product_config_wizard.action_next_step()
         product_config_wizard.write(
             {
-                "__attribute_{}".format(self.attr_fuel.id): self.value_gasoline.id,
-                "__attribute_{}".format(self.attr_engine.id): self.value_218i.id,
-                "__attribute_{}".format(self.attr_color.id): self.value_red.id,
+                f"__attribute_{self.attr_fuel.id}": self.value_gasoline.id,
+                f"__attribute_{self.attr_engine.id}": self.value_218i.id,
+                f"__attribute_{self.attr_color.id}": self.value_red.id,
             }
         )
         wizard_action = product_config_wizard.action_next_step()
@@ -235,14 +235,14 @@ class TestProduct(ProductConfiguratorTestCases):
         product_config_wizard.action_next_step()
         product_config_wizard.write(
             {
-                "__attribute_{}".format(self.attr_fuel.id): self.value_gasoline.id,
-                "__attribute_{}".format(self.attr_engine.id): self.value_218i.id,
+                f"__attribute_{self.attr_fuel.id}": self.value_gasoline.id,
+                f"__attribute_{self.attr_engine.id}": self.value_218i.id,
             }
         )
         product_config_wizard.action_next_step()
         product_config_wizard.write(
             {
-                "__attribute_{}".format(self.attr_color.id): self.value_red.id,
+                f"__attribute_{self.attr_color.id}": self.value_red.id,
             }
         )
         product_config_wizard.action_previous_step()
@@ -330,9 +330,9 @@ class TestProduct(ProductConfiguratorTestCases):
         product_config_wizard.action_next_step()
         product_config_wizard.write(
             {
-                "__attribute_{}".format(self.attr_fuel.id): self.value_gasoline.id,
-                "__attribute_{}".format(self.attr_engine.id): self.value_218i.id,
-                "__attribute_{}".format(self.attr_color.id): self.value_red.id,
+                f"__attribute_{self.attr_fuel.id}": self.value_gasoline.id,
+                f"__attribute_{self.attr_engine.id}": self.value_218i.id,
+                f"__attribute_{self.attr_color.id}": self.value_red.id,
             }
         )
         product_config_wizard.action_next_step()
@@ -347,14 +347,14 @@ class TestProduct(ProductConfiguratorTestCases):
         product_config_wizard.action_next_step()
         product_config_wizard.write(
             {
-                "__attribute_{}".format(self.attr_fuel.id): self.value_gasoline.id,
-                "__attribute_{}".format(self.attr_engine.id): self.value_218d.id,
+                f"__attribute_{self.attr_fuel.id}": self.value_gasoline.id,
+                f"__attribute_{self.attr_engine.id}": self.value_218d.id,
             }
         )
         product_config_wizard.action_next_step()
         product_config_wizard.write(
             {
-                "__attribute_{}".format(self.attr_color.id): self.value_silver.id,
+                f"__attribute_{self.attr_color.id}": self.value_silver.id,
             }
         )
         product_config_wizard.action_next_step()
@@ -618,9 +618,9 @@ class TestProduct(ProductConfiguratorTestCases):
         product_config_wizard.action_next_step()
         product_config_wizard.write(
             {
-                "__attribute_{}".format(self.attr_fuel.id): self.value_gasoline.id,
-                "__attribute_{}".format(self.attr_engine.id): self.value_218i.id,
-                "__attribute_{}".format(self.attr_color.id): self.value_red.id,
+                f"__attribute_{self.attr_fuel.id}": self.value_gasoline.id,
+                f"__attribute_{self.attr_engine.id}": self.value_218i.id,
+                f"__attribute_{self.attr_color.id}": self.value_red.id,
             }
         )
         product_config_wizard.action_next_step()

--- a/product_configurator/tests/test_product_attribute.py
+++ b/product_configurator/tests/test_product_attribute.py
@@ -4,7 +4,7 @@ from odoo.tests.common import TransactionCase
 
 class ProductAttributes(TransactionCase):
     def setUp(self):
-        super(ProductAttributes, self).setUp()
+        super().setUp()
         self.productAttributeLine = self.env["product.template.attribute.line"]
         self.ProductAttributeFuel = self.env.ref(
             "product_configurator.product_attribute_fuel"

--- a/product_configurator/tests/test_product_attribute.py
+++ b/product_configurator/tests/test_product_attribute.py
@@ -1,32 +1,37 @@
 from odoo.exceptions import ValidationError
 from odoo.tests.common import TransactionCase
 
+# FIXME: many tests here do not have any assertions.
+# They simply run something and expect it to not raise an exception.
+# This is not a good practice. Tests should have assertions.
 
-class ProductAttributes(TransactionCase):
-    def setUp(self):
-        super().setUp()
-        self.productAttributeLine = self.env["product.template.attribute.line"]
-        self.ProductAttributeFuel = self.env.ref(
+
+class ProductAttributes(BaseCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.productAttributeLine = cls.env["product.template.attribute.line"]
+        cls.ProductAttributeFuel = cls.env.ref(
             "product_configurator.product_attribute_fuel"
         )
-        self.ProductAttributeLineFuel = self.env.ref(
+        cls.ProductAttributeLineFuel = cls.env.ref(
             "product_configurator.product_attribute_line_2_series_fuel"
         )
-        self.ProductTemplate = self.env.ref("product_configurator.bmw_2_series")
-        self.product_category = self.env.ref("product.product_category_5")
-        self.ProductAttributePrice = self.env["product.template.attribute.value"]
-        self.attr_fuel = self.env.ref("product_configurator.product_attribute_fuel")
-        self.attr_engine = self.env.ref("product_configurator.product_attribute_engine")
-        self.value_diesel = self.env.ref(
+        cls.ProductTemplate = cls.env.ref("product_configurator.bmw_2_series")
+        cls.product_category = cls.env.ref("product.product_category_5")
+        cls.ProductAttributePrice = cls.env["product.template.attribute.value"]
+        cls.attr_fuel = cls.env.ref("product_configurator.product_attribute_fuel")
+        cls.attr_engine = cls.env.ref("product_configurator.product_attribute_engine")
+        cls.value_diesel = cls.env.ref(
             "product_configurator.product_attribute_value_diesel"
         )
-        self.value_218i = self.env.ref(
+        cls.value_218i = cls.env.ref(
             "product_configurator.product_attribute_value_218i"
         )
-        self.value_gasoline = self.env.ref(
+        cls.value_gasoline = cls.env.ref(
             "product_configurator.product_attribute_value_gasoline"
         )
-        self.ProductAttributeValueFuel = self.value_gasoline.attribute_id.id
+        cls.ProductAttributeValueFuel = cls.value_gasoline.attribute_id.id
 
     def test_01_onchange_custome_type(self):
         self.ProductAttributeFuel.min_val = 20
@@ -107,23 +112,27 @@ class ProductAttributes(TransactionCase):
         with self.assertRaises(ValidationError):
             self.ProductAttributeFuel.write({"max_val": 10, "min_val": 20})
 
-    def test_06_onchange_attribute(self):
-        with self.env.do_in_onchange():
-            self.ProductAttributeLineFuel.onchange_attribute()
-            self.assertFalse(
-                self.ProductAttributeLineFuel.value_ids, "value_ids is not False"
-            )
-            self.assertTrue(
-                self.ProductAttributeLineFuel.required, "required not exsits value"
-            )
-            self.ProductAttributeLineFuel.multi = True
-            self.assertTrue(
-                self.ProductAttributeLineFuel.multi, "multi not exsits value"
-            )
-            self.ProductAttributeLineFuel.custom = True
-            self.assertTrue(
-                self.ProductAttributeLineFuel.custom, "custom not exsits value"
-            )
+    # FIXME: broken on call `onchange_attribute` method as
+    # """
+    # odoo.exceptions.ValidationError:
+    # The attribute Fuel must have at least one value for the product 2 Series.
+    #
+    # def test_06_onchange_attribute(self):
+    #     self.ProductAttributeLineFuel.onchange_attribute()
+    #     self.assertFalse(
+    #         self.ProductAttributeLineFuel.value_ids, "value_ids is not False"
+    #     )
+    #     self.assertTrue(
+    #         self.ProductAttributeLineFuel.required, "required not exsits value"
+    #     )
+    #     self.ProductAttributeLineFuel.multi = True
+    #     self.assertTrue(
+    #         self.ProductAttributeLineFuel.multi, "multi not exsits value"
+    #     )
+    #     self.ProductAttributeLineFuel.custom = True
+    #     self.assertTrue(
+    #         self.ProductAttributeLineFuel.custom, "custom not exsits value"
+    #     )
 
     def test_07_check_default_values(self):
         with self.assertRaises(ValidationError):

--- a/product_configurator/tests/test_product_attribute.py
+++ b/product_configurator/tests/test_product_attribute.py
@@ -1,5 +1,6 @@
 from odoo.exceptions import ValidationError
-from odoo.tests.common import TransactionCase
+
+from odoo.addons.base.tests.common import BaseCommon
 
 # FIXME: many tests here do not have any assertions.
 # They simply run something and expect it to not raise an exception.

--- a/product_configurator/tests/test_product_config.py
+++ b/product_configurator/tests/test_product_config.py
@@ -5,7 +5,7 @@ from ..tests.common import ProductConfiguratorTestCases
 
 class ProductConfig(ProductConfiguratorTestCases):
     def setUp(self):
-        super(ProductConfig, self).setUp()
+        super().setUp()
         self.productConfWizard = self.env["product.configurator"]
         self.productTemplate = self.env["product.template"]
         self.productAttribute = self.env["product.attribute"]
@@ -355,8 +355,8 @@ class ProductConfig(ProductConfiguratorTestCases):
         product_config_wizard.action_next_step()
         product_config_wizard.write(
             {
-                "__attribute_{}".format(self.attribute_1.id): self.attribute_vals_1.id,
-                "__attribute_{}".format(self.attribute_2.id): self.attribute_vals_3.id,
+                f"__attribute_{self.attribute_1.id}": self.attribute_vals_1.id,
+                f"__attribute_{self.attribute_2.id}": self.attribute_vals_3.id,
             }
         )
         product_config_wizard.action_next_step()
@@ -471,10 +471,10 @@ class ProductConfig(ProductConfiguratorTestCases):
         product_config_wizard.action_next_step()
         product_config_wizard.write(
             {
-                "__attribute_{}".format(self.attribute_1.id): self.custom_vals.id,
-                "__custom_{}".format(self.attribute_1.id): self.irAttachement.id,
-                "__attribute_{}".format(self.attribute_1.id): self.custom_vals.id,
-                "__custom_{}".format(self.attribute_1.id): "Test",
+                f"__attribute_{self.attribute_1.id}": self.custom_vals.id,
+                f"__custom_{self.attribute_1.id}": self.irAttachement.id,
+                f"__attribute_{self.attribute_1.id}": self.custom_vals.id,
+                f"__custom_{self.attribute_1.id}": "Test",
             }
         )
         product_config_wizard.action_next_step()
@@ -566,10 +566,10 @@ class ProductConfig(ProductConfiguratorTestCases):
         product_config_wizard.action_next_step()
         product_config_wizard.write(
             {
-                "__attribute_{}".format(self.attribute_1.id): self.custom_vals.id,
-                "__custom_{}".format(self.attribute_1.id): self.irAttachement.id,
-                "__attribute_{}".format(self.attribute_1.id): self.custom_vals.id,
-                "__custom_{}".format(self.attribute_1.id): "Test",
+                f"__attribute_{self.attribute_1.id}": self.custom_vals.id,
+                f"__custom_{self.attribute_1.id}": self.irAttachement.id,
+                f"__attribute_{self.attribute_1.id}": self.custom_vals.id,
+                f"__custom_{self.attribute_1.id}": "Test",
             }
         )
         self.attributeLine1.custom = False

--- a/product_configurator/tests/test_product_config.py
+++ b/product_configurator/tests/test_product_config.py
@@ -2,104 +2,101 @@ from odoo.exceptions import UserError, ValidationError
 
 from ..tests.common import ProductConfiguratorTestCases
 
+# FIXME: many tests here do not have any assertions.
+# They simply run something and expect it to not raise an exception.
+# This is not a good practice. Tests should have assertions.
+
 
 class ProductConfig(ProductConfiguratorTestCases):
-    def setUp(self):
-        super().setUp()
-        self.productConfWizard = self.env["product.configurator"]
-        self.productTemplate = self.env["product.template"]
-        self.productAttribute = self.env["product.attribute"]
-        self.productAttributeVals = self.env["product.attribute.value"]
-        self.productAttributeLine = self.env["product.template.attribute.line"]
-        self.productConfigSession = self.env["product.config.session"]
-        self.productConfigDomain = self.env["product.config.domain"]
-        self.config_product = self.env.ref("product_configurator.bmw_2_series")
-        self.attr_engine = self.env.ref("product_configurator.product_attribute_engine")
-        self.config_step_engine = self.env.ref(
-            "product_configurator.config_step_engine"
-        )
-        self.config_product_1 = self.env.ref(
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.productConfWizard = cls.env["product.configurator"]
+        cls.productTemplate = cls.env["product.template"]
+        cls.productAttribute = cls.env["product.attribute"]
+        cls.productAttributeVals = cls.env["product.attribute.value"]
+        cls.productAttributeLine = cls.env["product.template.attribute.line"]
+        cls.productConfigSession = cls.env["product.config.session"]
+        cls.productConfigDomain = cls.env["product.config.domain"]
+        cls.config_product = cls.env.ref("product_configurator.bmw_2_series")
+        cls.attr_engine = cls.env.ref("product_configurator.product_attribute_engine")
+        cls.config_step_engine = cls.env.ref("product_configurator.config_step_engine")
+        cls.config_product_1 = cls.env.ref(
             "product_configurator.product_config_line_gasoline_engines"
         )
-        self.config_product_2 = self.env.ref(
+        cls.config_product_2 = cls.env.ref(
             "product_configurator.2_series_config_step_body"
         )
         # domain
-        self.domain_gasolin = self.env.ref(
+        cls.domain_gasolin = cls.env.ref(
             "product_configurator.product_config_domain_gasoline"
         )
-        self.domain_engine = self.env.ref(
+        cls.domain_engine = cls.env.ref(
             "product_configurator.product_config_domain_diesel"
         )
-        self.config_image_red = self.env.ref("product_configurator.config_image_1")
+        cls.config_image_red = cls.env.ref("product_configurator.config_image_1")
         # value
-        self.value_gasoline = self.env.ref(
+        cls.value_gasoline = cls.env.ref(
             "product_configurator.product_attribute_value_gasoline"
         )
-        self.value_diesel = self.env.ref(
+        cls.value_diesel = cls.env.ref(
             "product_configurator.product_attribute_value_diesel"
         )
-        self.value_red = self.env.ref(
-            "product_configurator.product_attribute_value_red"
-        )
+        cls.value_red = cls.env.ref("product_configurator.product_attribute_value_red")
         # config_step
-        self.config_step_engine = self.env.ref(
-            "product_configurator.config_step_engine"
-        )
-        self.attribute_line = self.env.ref(
+        cls.config_step_engine = cls.env.ref("product_configurator.config_step_engine")
+        cls.attribute_line = cls.env.ref(
             "product_configurator.product_attribute_line_2_series_engine"
         )
-        self.value_silver = self.env.ref(
+        cls.value_silver = cls.env.ref(
             "product_configurator.product_attribute_value_silver"
         )
-        self.value_rims_387 = self.env.ref(
+        cls.value_rims_387 = cls.env.ref(
             "product_configurator.product_attribute_value_rims_387"
         )
         # attribute line
-        self.attribute_line_2_series_rims = self.env.ref(
+        cls.attribute_line_2_series_rims = cls.env.ref(
             "product_configurator.product_attribute_line_2_series_rims"
         )
-        self.attribute_line_2_series_tapistry = self.env.ref(
+        cls.attribute_line_2_series_tapistry = cls.env.ref(
             "product_configurator.product_attribute_line_2_series_tapistry"
         )
-        self.attribute_value_tapistry_oyster_black = self.env.ref(
+        cls.attribute_value_tapistry_oyster_black = cls.env.ref(
             "product_configurator." + "product_attribute_value_tapistry_oyster_black"
         )
-        self.attribute_line_2_series_transmission = self.env.ref(
+        cls.attribute_line_2_series_transmission = cls.env.ref(
             "product_configurator.product_attribute_line_2_series_transmission"
         )
 
         # attribute value
-        self.attribute_rims = self.env.ref(
-            "product_configurator.product_attribute_rims"
-        )
-        self.attribute_tapistry = self.env.ref(
+        cls.attribute_rims = cls.env.ref("product_configurator.product_attribute_rims")
+        cls.attribute_tapistry = cls.env.ref(
             "product_configurator.product_attribute_tapistry"
         )
-        self.attribute_transmission = self.env.ref(
+        cls.attribute_transmission = cls.env.ref(
             "product_configurator.product_attribute_transmission"
         )
 
         # session id
-        self.session_id = self.productConfigSession.create(
+        cls.session_id = cls.productConfigSession.create(
             {
-                "product_tmpl_id": self.config_product.id,
+                "product_tmpl_id": cls.config_product.id,
                 "value_ids": [
                     (
                         6,
                         0,
                         [
-                            self.value_gasoline.id,
-                            self.value_transmission.id,
-                            self.value_red.id,
+                            cls.value_gasoline.id,
+                            cls.value_transmission.id,
+                            cls.value_red.id,
                         ],
                     )
                 ],
-                "user_id": self.env.user.id,
+                "user_id": cls.env.user.id,
             }
         )
         # ir attachment
-        self.irAttachement = self.env["ir.attachment"].create(
+        cls.irAttachement = cls.env["ir.attachment"].create(
             {
                 "name": "Test attachement",
                 "datas": "bWlncmF0aW9uIHRlc3Q=",
@@ -107,52 +104,52 @@ class ProductConfig(ProductConfiguratorTestCases):
         )
 
         # configure product
-        self._configure_product_nxt_step()
-        self.config_session = self.productConfigSession.search(
-            [("product_tmpl_id", "=", self.config_product.id)]
+        cls._configure_product_nxt_step()
+        cls.config_session = cls.productConfigSession.search(
+            [("product_tmpl_id", "=", cls.config_product.id)]
         )
 
         # create product template
-        self.product_tmpl_id = self.productTemplate.create({"name": "Coca-Cola"})
+        cls.product_tmpl_id = cls.productTemplate.create({"name": "Coca-Cola"})
         # create attribute 1
-        self.attribute_1 = self.productAttribute.create(
+        cls.attribute_1 = cls.productAttribute.create(
             {
                 "name": "Color",
             }
         )
         # create attribute 2
-        self.attribute_2 = self.productAttribute.create(
+        cls.attribute_2 = cls.productAttribute.create(
             {
                 "name": "Flavour",
             }
         )
 
         # create attribute value 1
-        self.attribute_vals_1 = self.productAttributeVals.create(
+        cls.attribute_vals_1 = cls.productAttributeVals.create(
             {
                 "name": "Orange",
-                "attribute_id": self.attribute_1.id,
+                "attribute_id": cls.attribute_1.id,
             }
         )
         # create attribute value 2
-        self.attribute_vals_2 = self.productAttributeVals.create(
+        cls.attribute_vals_2 = cls.productAttributeVals.create(
             {
                 "name": "Balck",
-                "attribute_id": self.attribute_1.id,
+                "attribute_id": cls.attribute_1.id,
             }
         )
         # create attribute value 3
-        self.attribute_vals_3 = self.productAttributeVals.create(
+        cls.attribute_vals_3 = cls.productAttributeVals.create(
             {
                 "name": "Coke",
-                "attribute_id": self.attribute_2.id,
+                "attribute_id": cls.attribute_2.id,
             }
         )
         # create attribute value 4
-        self.attribute_vals_4 = self.productAttributeVals.create(
+        cls.attribute_vals_4 = cls.productAttributeVals.create(
             {
                 "name": "Mango",
-                "attribute_id": self.attribute_2.id,
+                "attribute_id": cls.attribute_2.id,
             }
         )
 
@@ -319,7 +316,7 @@ class ProductConfig(ProductConfiguratorTestCases):
 
     def test_09_create_get_variant(self):
         # configure new product to check for search not dublicate variant
-        self.attributeLine1 = self.productAttributeLine.create(
+        attributeLine1 = self.productAttributeLine.create(
             {
                 "product_tmpl_id": self.product_tmpl_id.id,
                 "attribute_id": self.attribute_1.id,
@@ -329,7 +326,7 @@ class ProductConfig(ProductConfiguratorTestCases):
             }
         )
         # create attribute line 2
-        self.attributeLine2 = self.productAttributeLine.create(
+        attributeLine2 = self.productAttributeLine.create(
             {
                 "product_tmpl_id": self.product_tmpl_id.id,
                 "attribute_id": self.attribute_2.id,
@@ -340,9 +337,7 @@ class ProductConfig(ProductConfiguratorTestCases):
         )
         self.product_tmpl_id.write(
             {
-                "attribute_line_ids": [
-                    (6, 0, [self.attributeLine1.id, self.attributeLine2.id])
-                ],
+                "attribute_line_ids": [(6, 0, [attributeLine1.id, attributeLine2.id])],
             }
         )
         self.product_tmpl_id.configure_product()
@@ -370,15 +365,22 @@ class ProductConfig(ProductConfiguratorTestCases):
             "Error: If Not Equal variant name\
             Method: search_variant()",
         )
-        self.attributeLine1.custom = True
-        self.env["product.config.session.custom.value"].create(
-            {
-                "cfg_session_id": config_session_1.id,
-                "attribute_id": self.attribute_1.id,
-                "value": "Coke",
-            }
-        )
-        config_session_1.create_get_variant()
+        # FIXME: broken when running `attributeLine1.custom = True`
+        #   """
+        #   psycopg2.errors.UniqueViolation:
+        #   duplicate key value violates unique constraint
+        #   "product_product_combination_unique"
+        #   DETAIL:  Key (product_tmpl_id, combination_indices)=(81, 459,461)
+        #       already exists.
+        # attributeLine1.custom = True
+        # self.env["product.config.session.custom.value"].create(
+        #     {
+        #         "cfg_session_id": config_session_1.id,
+        #         "attribute_id": self.attribute_1.id,
+        #         "value": "Coke",
+        #     }
+        # )
+        # config_session_1.create_get_variant()
 
     def test_10_check_value_ids(self):
         with self.assertRaises(ValidationError):
@@ -403,29 +405,36 @@ class ProductConfig(ProductConfiguratorTestCases):
                 }
             )
 
-    def test_12_get_cfg_weight(self):
-        self.env["product.template.attribute.value"].create(
-            {
-                "product_tmpl_id": self.config_product.id,
-                "product_attribute_value_id": self.value_red.id,
-                "weight_extra": 20.0,
-            }
-        )
-        self.config_product.weight = 20
-        weightVal = self.config_session.get_cfg_weight()
-        self.assertEqual(
-            weightVal,
-            40.0,
-            "Error: If Value are not equal\
-            Method: get_cfg_weight()",
-        )
-        # check for config weight
-        self.assertEqual(
-            self.config_session.weight,
-            40.0,
-            "Error: If config weight are not equal\
-            Method: _compute_cfg_weight()",
-        )
+    # FIXME: broken at the first create as
+    #   """
+    #   psycopg2.errors.NotNullViolation
+    #     null value in column "attribute_line_id" of
+    #     relation "product_template_attribute_value"
+    #     violates not-null constraint
+    #   DETAIL:  Failing row contains ...
+    # def test_12_get_cfg_weight(self):
+    #     self.env["product.template.attribute.value"].create(
+    #         {
+    #             "product_tmpl_id": self.config_product.id,
+    #             "product_attribute_value_id": self.value_red.id,
+    #             "weight_extra": 20.0,
+    #         }
+    #     )
+    #     self.config_product.weight = 20
+    #     weightVal = self.config_session.get_cfg_weight()
+    #     self.assertEqual(
+    #         weightVal,
+    #         40.0,
+    #         "Error: If Value are not equal\
+    #         Method: get_cfg_weight()",
+    #     )
+    #     # check for config weight
+    #     self.assertEqual(
+    #         self.config_session.weight,
+    #         40.0,
+    #         "Error: If config weight are not equal\
+    #         Method: _compute_cfg_weight()",
+    #     )
 
     def test_13_update_session_configuration_value(self):
         # configure new product to check for search not dublicate variant
@@ -475,29 +484,39 @@ class ProductConfig(ProductConfiguratorTestCases):
                 f"__custom_{self.attribute_1.id}": "Test",
             }
         )
-        product_config_wizard.action_next_step()
+        # FIXME: broken validation at `product_config.create_get_variant`
+        #   """
+        #   odoo.exceptions.ValidationError: Required attribute 'Flavour' is empty
+        # product_config_wizard.action_next_step()
 
-    def test_14_get_cfg_price(self):
-        self.env["product.template.attribute.value"].create(
-            {
-                "product_tmpl_id": self.config_product.id,
-                "product_attribute_value_id": self.value_red.id,
-                "weight_extra": 20.0,
-                "price_extra": 20.0,
-            }
-        )
-        price = self.config_product.list_price
-        price += self.value_220i.product_id.lst_price
-        price += self.value_model_sport_line.product_id.lst_price
-        price += self.value_transmission.product_id.lst_price
-        price += self.value_options_2.product_id.lst_price
-        price_extra_val = self.session_id.get_cfg_price()
-        self.assertEqual(
-            price_extra_val,
-            price + 20,
-            "Error: If not equal price extra\
-            Method: get_cfg_price()",
-        )
+    # FIXME: broken at the first create as
+    #   """
+    #   psycopg2.errors.NotNullViolation
+    #     null value in column "attribute_line_id" of
+    #     relation "product_template_attribute_value"
+    #     violates not-null constraint
+    #   DETAIL:  Failing row contains ...
+    # def test_14_get_cfg_price(self):
+    #     self.env["product.template.attribute.value"].create(
+    #         {
+    #             "product_tmpl_id": self.config_product.id,
+    #             "product_attribute_value_id": self.value_red.id,
+    #             "weight_extra": 20.0,
+    #             "price_extra": 20.0,
+    #         }
+    #     )
+    #     price = self.config_product.list_price
+    #     price += self.value_220i.product_id.lst_price
+    #     price += self.value_model_sport_line.product_id.lst_price
+    #     price += self.value_transmission.product_id.lst_price
+    #     price += self.value_options_2.product_id.lst_price
+    #     price_extra_val = self.session_id.get_cfg_price()
+    #     self.assertEqual(
+    #         price_extra_val,
+    #         price + 20,
+    #         "Error: If not equal price extra\
+    #         Method: get_cfg_price()",
+    #     )
 
     def test_15_get_next_step(self):
         self.session_id.get_next_step(state=None)
@@ -628,7 +647,7 @@ class ProductConfig(ProductConfiguratorTestCases):
         )
         self.productConfigDomainId.compute_domain()
         # create attribute value line 1
-        config_line = self.env["product.config.line"].create(
+        config_line = self.env["product.config.line"].create(  # noqa
             {
                 "product_tmpl_id": self.product_tmpl_id.id,
                 "attribute_line_id": self.attributeLine1.id,
@@ -638,14 +657,21 @@ class ProductConfig(ProductConfiguratorTestCases):
                 "domain_id": self.productConfigDomainId.id,
             }
         )
-        with self.assertRaises(ValidationError):
-            config_line.onchange_attribute()
+        # FIXME: broken as
+        #   """
+        #   psycopg2.errors.NotNullViolation:
+        #   null value in column "domain_id"
+        #   of relation "product_config_line"
+        #   violates not-null constraint
+        #   DETAIL:  Failing row contains ...
+        # with self.assertRaises(ValidationError):
+        #     config_line.onchange_attribute()
 
-        self.assertFalse(
-            config_line.value_ids,
-            "Error: If value_ids True\
-            Method: onchange_attribute()",
-        )
+        # self.assertFalse(
+        #     config_line.value_ids,
+        #     "Error: If value_ids True\
+        #     Method: onchange_attribute()",
+        # )
 
     def test_19_eval(self):
         self.attr_color.custom_type = "binary"

--- a/product_configurator/tests/test_product_config.py
+++ b/product_configurator/tests/test_product_config.py
@@ -472,8 +472,6 @@ class ProductConfig(ProductConfiguratorTestCases):
         product_config_wizard.write(
             {
                 f"__attribute_{self.attribute_1.id}": self.custom_vals.id,
-                f"__custom_{self.attribute_1.id}": self.irAttachement.id,
-                f"__attribute_{self.attribute_1.id}": self.custom_vals.id,
                 f"__custom_{self.attribute_1.id}": "Test",
             }
         )
@@ -566,8 +564,6 @@ class ProductConfig(ProductConfiguratorTestCases):
         product_config_wizard.action_next_step()
         product_config_wizard.write(
             {
-                f"__attribute_{self.attribute_1.id}": self.custom_vals.id,
-                f"__custom_{self.attribute_1.id}": self.irAttachement.id,
                 f"__attribute_{self.attribute_1.id}": self.custom_vals.id,
                 f"__custom_{self.attribute_1.id}": "Test",
             }

--- a/product_configurator/tests/test_wizard.py
+++ b/product_configurator/tests/test_wizard.py
@@ -2,52 +2,55 @@ from odoo.exceptions import UserError
 
 from ..tests.common import ProductConfiguratorTestCases
 
+# FIXME: many tests here do not have any assertions.
+# They simply run something and expect it to not raise an exception.
+# This is not a good practice. Tests should have assertions.
+
 
 class ConfigurationWizard(ProductConfiguratorTestCases):
-    def setUp(self):
-        super().setUp()
-        self.productTemplate = self.env["product.template"]
-        self.productAttributeLine = self.env["product.template.attribute.line"]
-        self.productConfigStepLine = self.env["product.config.step.line"]
-        self.productConfigSession = self.env["product.config.session"]
-        self.product_category = self.env.ref("product.product_category_5")
-        self.attr_line_fuel = self.env.ref(
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.productTemplate = cls.env["product.template"]
+        cls.productAttributeLine = cls.env["product.template.attribute.line"]
+        cls.productConfigStepLine = cls.env["product.config.step.line"]
+        cls.productConfigSession = cls.env["product.config.session"]
+        cls.product_category = cls.env.ref("product.product_category_5")
+        cls.attr_line_fuel = cls.env.ref(
             "product_configurator.product_attribute_line_2_series_fuel"
         )
-        self.attr_line_engine = self.env.ref(
+        cls.attr_line_engine = cls.env.ref(
             "product_configurator.product_attribute_line_2_series_engine"
         )
-        self.value_diesel = self.env.ref(
+        cls.value_diesel = cls.env.ref(
             "product_configurator.product_attribute_value_diesel"
         )
-        self.value_218d = self.env.ref(
+        cls.value_218d = cls.env.ref(
             "product_configurator.product_attribute_value_218d"
         )
-        self.value_220d = self.env.ref(
+        cls.value_220d = cls.env.ref(
             "product_configurator.product_attribute_value_220d"
         )
-        self.value_silver = self.env.ref(
+        cls.value_silver = cls.env.ref(
             "product_configurator.product_attribute_value_silver"
         )
-        self.config_step_engine = self.env.ref(
-            "product_configurator.config_step_engine"
-        )
-        self.config_step_body = self.env.ref("product_configurator.config_step_body")
-        self.product_tmpl_id = self.env["product.template"].create(
+        cls.config_step_engine = cls.env.ref("product_configurator.config_step_engine")
+        cls.config_step_body = cls.env.ref("product_configurator.config_step_body")
+        cls.product_tmpl_id = cls.env["product.template"].create(
             {
                 "name": "Test Configuration",
                 "config_ok": True,
                 "type": "consu",
-                "categ_id": self.product_category.id,
+                "categ_id": cls.product_category.id,
             }
         )
-        self.custom_vals = self.productConfigSession.get_custom_value_id()
-        self.cfg_tmpl = self.env.ref("product_configurator.bmw_2_series")
+        cls.custom_vals = cls.productConfigSession.get_custom_value_id()
+        cls.cfg_tmpl = cls.env.ref("product_configurator.bmw_2_series")
 
-        attribute_vals = self.cfg_tmpl.attribute_line_ids.mapped("value_ids")
-        self.attr_vals = attribute_vals
+        attribute_vals = cls.cfg_tmpl.attribute_line_ids.mapped("value_ids")
+        cls.attr_vals = attribute_vals
 
-        self.attr_val_ext_ids = {
+        cls.attr_val_ext_ids = {
             v: k for k, v in attribute_vals.get_external_id().items()
         }
 
@@ -237,26 +240,34 @@ class ConfigurationWizard(ProductConfiguratorTestCases):
         step_to_open = wizard.config_session_id.check_and_open_incomplete_step()
         wizard.open_step(step_to_open)
 
-    def test_11_onchange(self):
-        field_name = ""
-        values = {f"__attribute_{self.attr_fuel.id}": self.value_gasoline.id}
-        product_config_wizard = self._check_wizard_nxt_step()
-        field_prefix = product_config_wizard._prefixes.get("field_prefix")
-        field_name = f"{field_prefix}{field_name}"
-        specs = product_config_wizard._onchange_spec()
-        product_config_wizard.onchange(values, field_name, specs)
-
-        product_config_wizard.attribute_line_ids.update(
-            {
-                "attribute_id": self.attr_fuel.id,
-                "custom": True,
-            }
-        )
-        values2 = {
-            f"__attribute_{self.attr_fuel.id}": self.custom_vals.id,
-            f"__custom_{self.attr_fuel.id}": "Test1",
-        }
-        product_config_wizard.onchange(values2, field_name, specs)
+    # FIXME: broken test
+    # Fails at `product_config_wizard.attribute_line_ids.update(` as
+    #     """odoo.exceptions.UserError:
+    #     On the product Test Configuration
+    #     you cannot transform the attribute Engine into the attribute 5."""
+    #
+    # Also, the test is not very useful. It does not assert anything.
+    #
+    # def test_11_onchange(self):
+    #     field_name = ""
+    #     values = {f"__attribute_{self.attr_fuel.id}": self.value_gasoline.id}
+    #     product_config_wizard = self._check_wizard_nxt_step()
+    #     field_prefix = product_config_wizard._prefixes.get("field_prefix")
+    #     field_name = f"{field_prefix}{field_name}"
+    #     specs = product_config_wizard._onchange_spec()
+    #     product_config_wizard.onchange(values, field_name, specs)
+    #
+    #     product_config_wizard.attribute_line_ids.update(
+    #         {
+    #             "attribute_id": self.attr_fuel.id,
+    #             "custom": True,
+    #         }
+    #     )
+    #     values2 = {
+    #         f"__attribute_{self.attr_fuel.id}": self.custom_vals.id,
+    #         f"__custom_{self.attr_fuel.id}": "Test1",
+    #     }
+    #     product_config_wizard.onchange(values2, field_name, specs)
 
     def test_12_fields_get(self):
         product_config_wizard = self._check_wizard_nxt_step()

--- a/product_configurator/tests/test_wizard.py
+++ b/product_configurator/tests/test_wizard.py
@@ -5,7 +5,7 @@ from ..tests.common import ProductConfiguratorTestCases
 
 class ConfigurationWizard(ProductConfiguratorTestCases):
     def setUp(self):
-        super(ConfigurationWizard, self).setUp()
+        super().setUp()
         self.productTemplate = self.env["product.template"]
         self.productAttributeLine = self.env["product.template.attribute.line"]
         self.productConfigStepLine = self.env["product.config.step.line"]
@@ -113,14 +113,14 @@ class ConfigurationWizard(ProductConfiguratorTestCases):
         product_config_wizard.action_next_step()
         product_config_wizard.write(
             {
-                "__attribute_{}".format(self.attr_fuel.id): self.value_gasoline.id,
-                "__attribute_{}".format(self.attr_engine.id): self.value_218i.id,
+                f"__attribute_{self.attr_fuel.id}": self.value_gasoline.id,
+                f"__attribute_{self.attr_engine.id}": self.value_218i.id,
             }
         )
         product_config_wizard.action_next_step()
         product_config_wizard.write(
             {
-                "__attribute_{}".format(self.attr_color.id): self.value_red.id,
+                f"__attribute_{self.attr_color.id}": self.value_red.id,
             }
         )
         return product_config_wizard
@@ -239,10 +239,10 @@ class ConfigurationWizard(ProductConfiguratorTestCases):
 
     def test_11_onchange(self):
         field_name = ""
-        values = {"__attribute_{}".format(self.attr_fuel.id): self.value_gasoline.id}
+        values = {f"__attribute_{self.attr_fuel.id}": self.value_gasoline.id}
         product_config_wizard = self._check_wizard_nxt_step()
         field_prefix = product_config_wizard._prefixes.get("field_prefix")
-        field_name = "%s%s" % (field_prefix, field_name)
+        field_name = f"{field_prefix}{field_name}"
         specs = product_config_wizard._onchange_spec()
         product_config_wizard.onchange(values, field_name, specs)
 
@@ -253,8 +253,8 @@ class ConfigurationWizard(ProductConfiguratorTestCases):
             }
         )
         values2 = {
-            "__attribute_{}".format(self.attr_fuel.id): self.custom_vals.id,
-            "__custom_{}".format(self.attr_fuel.id): "Test1",
+            f"__attribute_{self.attr_fuel.id}": self.custom_vals.id,
+            f"__custom_{self.attr_fuel.id}": "Test1",
         }
         product_config_wizard.onchange(values2, field_name, specs)
 
@@ -276,56 +276,50 @@ class ConfigurationWizard(ProductConfiguratorTestCases):
         product_config_wizard_1.action_next_step()
         product_config_wizard_1.write(
             {
-                "__attribute_{}".format(self.attr_fuel.id): self.value_gasoline.id,
-                "__custom_{}".format(self.attr_fuel.id): "Test1",
-                "__attribute_{}".format(self.attr_engine.id): self.value_218i.id,
-                "__custom_{}".format(self.attr_engine.id): "Test2",
+                f"__attribute_{self.attr_fuel.id}": self.value_gasoline.id,
+                f"__custom_{self.attr_fuel.id}": "Test1",
+                f"__attribute_{self.attr_engine.id}": self.value_218i.id,
+                f"__custom_{self.attr_engine.id}": "Test2",
             }
         )
         product_config_wizard_1.action_next_step()
         product_config_wizard_1.write(
             {
-                "__attribute_{}".format(self.attr_color.id): self.value_red.id,
-                "__attribute_{}".format(self.attr_rims.id): self.value_rims_378.id,
+                f"__attribute_{self.attr_color.id}": self.value_red.id,
+                f"__attribute_{self.attr_rims.id}": self.value_rims_378.id,
             }
         )
         product_config_wizard_1.action_next_step()
         product_config_wizard_1.write(
             {
-                "__attribute_{}".format(
-                    self.attr_model_line.id
-                ): self.value_sport_line.id,
+                f"__attribute_{self.attr_model_line.id}": self.value_sport_line.id,
             }
         )
         product_config_wizard_1.action_previous_step()
         product_config_wizard_1.action_previous_step()
         product_config_wizard_1.write(
             {
-                "__attribute_{}".format(self.attr_engine.id): self.value_220i.id,
+                f"__attribute_{self.attr_engine.id}": self.value_220i.id,
             }
         )
         product_config_wizard_1.action_next_step()
         product_config_wizard_1.action_next_step()
         product_config_wizard_1.write(
             {
-                "__attribute_{}".format(
-                    self.attr_model_line.id
-                ): self.value_model_sport_line.id,
+                f"__attribute_{self.attr_model_line.id}": self.value_model_sport_line.id,
             }
         )
         product_config_wizard_1.action_next_step()
         product_config_wizard_1.write(
             {
-                "__attribute_{}".format(self.attr_tapistry.id): self.value_tapistry.id,
+                f"__attribute_{self.attr_tapistry.id}": self.value_tapistry.id,
             }
         )
         product_config_wizard_1.action_next_step()
         product_config_wizard_1.write(
             {
-                "__attribute_{}".format(
-                    self.attr_transmission.id
-                ): self.value_transmission.id,
-                "__attribute_{}".format(self.attr_options.id): [
+                f"__attribute_{self.attr_transmission.id}": self.value_transmission.id,
+                f"__attribute_{self.attr_options.id}": [
                     [6, 0, [self.value_options_2.id]]
                 ],
             }
@@ -353,56 +347,50 @@ class ConfigurationWizard(ProductConfiguratorTestCases):
         product_config_wizard_1.action_next_step()
         product_config_wizard_1.write(
             {
-                "__attribute_{}".format(self.attr_fuel.id): self.value_gasoline.id,
-                "__custom_{}".format(self.attr_fuel.id): "Test1",
-                "__attribute_{}".format(self.attr_engine.id): self.value_218i.id,
-                "__custom_{}".format(self.attr_engine.id): "Test2",
+                f"__attribute_{self.attr_fuel.id}": self.value_gasoline.id,
+                f"__custom_{self.attr_fuel.id}": "Test1",
+                f"__attribute_{self.attr_engine.id}": self.value_218i.id,
+                f"__custom_{self.attr_engine.id}": "Test2",
             }
         )
         product_config_wizard_1.action_next_step()
         product_config_wizard_1.write(
             {
-                "__attribute_{}".format(self.attr_color.id): self.value_red.id,
-                "__attribute_{}".format(self.attr_rims.id): self.value_rims_378.id,
+                f"__attribute_{self.attr_color.id}": self.value_red.id,
+                f"__attribute_{self.attr_rims.id}": self.value_rims_378.id,
             }
         )
         product_config_wizard_1.action_next_step()
         product_config_wizard_1.write(
             {
-                "__attribute_{}".format(
-                    self.attr_model_line.id
-                ): self.value_sport_line.id,
+                f"__attribute_{self.attr_model_line.id}": self.value_sport_line.id,
             }
         )
         product_config_wizard_1.action_previous_step()
         product_config_wizard_1.action_previous_step()
         product_config_wizard_1.write(
             {
-                "__attribute_{}".format(self.attr_engine.id): self.value_220i.id,
+                f"__attribute_{self.attr_engine.id}": self.value_220i.id,
             }
         )
         product_config_wizard_1.action_next_step()
         product_config_wizard_1.action_next_step()
         product_config_wizard_1.write(
             {
-                "__attribute_{}".format(
-                    self.attr_model_line.id
-                ): self.value_model_sport_line.id,
+                f"__attribute_{self.attr_model_line.id}": self.value_model_sport_line.id,
             }
         )
         product_config_wizard_1.action_next_step()
         product_config_wizard_1.write(
             {
-                "__attribute_{}".format(self.attr_tapistry.id): self.value_tapistry.id,
+                f"__attribute_{self.attr_tapistry.id}": self.value_tapistry.id,
             }
         )
         product_config_wizard_1.action_next_step()
         product_config_wizard_1.write(
             {
-                "__attribute_{}".format(
-                    self.attr_transmission.id
-                ): self.value_transmission.id,
-                "__attribute_{}".format(self.attr_options.id): [
+                f"__attribute_{self.attr_transmission.id}": self.value_transmission.id,
+                f"__attribute_{self.attr_options.id}": [
                     [6, 0, [self.value_options_2.id]]
                 ],
             }
@@ -424,9 +412,9 @@ class ConfigurationWizard(ProductConfiguratorTestCases):
     def test_15_read(self):
         product_config_wizard = self._check_wizard_nxt_step()
         values = {
-            "__attribute_{}".format(self.attr_fuel.id): self.value_gasoline.id,
-            "__attribute_{}".format(self.attr_engine.id): self.value_218i.id,
-            "__attribute_{}".format(self.attr_color.id): self.value_red.id,
+            f"__attribute_{self.attr_fuel.id}": self.value_gasoline.id,
+            f"__attribute_{self.attr_engine.id}": self.value_218i.id,
+            f"__attribute_{self.attr_color.id}": self.value_red.id,
         }
         product_config_wizard.read(values)
         product_tmpl = self.env["product.template"].create(
@@ -500,25 +488,25 @@ class ConfigurationWizard(ProductConfiguratorTestCases):
         product_config_wizard_1.action_next_step()
         product_config_wizard_1.write(
             {
-                "__attribute_{}".format(self.attr_fuel.id): self.custom_vals.id,
-                "__custom_{}".format(self.attr_fuel.id): "#DEFSRE",
-                "__attribute_{}".format(self.attr_engine.id): self.custom_vals.id,
-                "__custom_{}".format(self.attr_engine.id): "#FERDFGR",
+                f"__attribute_{self.attr_fuel.id}": self.custom_vals.id,
+                f"__custom_{self.attr_fuel.id}": "#DEFSRE",
+                f"__attribute_{self.attr_engine.id}": self.custom_vals.id,
+                f"__custom_{self.attr_engine.id}": "#FERDFGR",
             }
         )
         product_config_wizard_1.action_next_step()
         product_config_wizard_1.write(
             {
-                "__attribute_{}".format(self.attr_color.id): self.value_red.id,
+                f"__attribute_{self.attr_color.id}": self.value_red.id,
             }
         )
         # check for custom value
         custom_vals = {
-            "__attribute_{}".format(self.attr_fuel.id): self.custom_vals.id,
-            "__custom_{}".format(self.attr_fuel.id): "#DEFSRE",
-            "__attribute_{}".format(self.attr_engine.id): self.custom_vals.id,
-            "__custom_{}".format(self.attr_engine.id): "#FERDFGR",
-            "__attribute_{}".format(self.attr_color.id): self.value_red.id,
+            f"__attribute_{self.attr_fuel.id}": self.custom_vals.id,
+            f"__custom_{self.attr_fuel.id}": "#DEFSRE",
+            f"__attribute_{self.attr_engine.id}": self.custom_vals.id,
+            f"__custom_{self.attr_engine.id}": "#FERDFGR",
+            f"__attribute_{self.attr_color.id}": self.value_red.id,
         }
         product_config_wizard_1.read(custom_vals)
         session = self.productConfigSession.search(
@@ -536,27 +524,27 @@ class ConfigurationWizard(ProductConfiguratorTestCases):
         product_config_wizard_2.action_next_step()
         product_config_wizard_2.write(
             {
-                "__attribute_{}".format(self.attr_fuel.id): [
+                f"__attribute_{self.attr_fuel.id}": [
                     (6, 0, [self.value_diesel.id, self.value_gasoline.id])
                 ],
-                "__attribute_{}".format(self.attr_engine.id): self.custom_vals.id,
-                "__custom_{}".format(self.attr_engine.id): "#FERDFGR",
+                f"__attribute_{self.attr_engine.id}": self.custom_vals.id,
+                f"__custom_{self.attr_engine.id}": "#FERDFGR",
             }
         )
         product_config_wizard_2.action_next_step()
         product_config_wizard_2.write(
             {
-                "__attribute_{}".format(self.attr_color.id): self.value_red.id,
+                f"__attribute_{self.attr_color.id}": self.value_red.id,
             }
         )
         # check for multi value
         multi_vals = {
-            "__attribute_{}".format(self.attr_fuel.id): [
+            f"__attribute_{self.attr_fuel.id}": [
                 (6, 0, [self.value_diesel.id, self.value_gasoline.id])
             ],
-            "__attribute_{}".format(self.attr_engine.id): self.custom_vals.id,
-            "__custom_{}".format(self.attr_engine.id): "#FERDFGR",
-            "__attribute_{}".format(self.attr_color.id): self.value_red.id,
+            f"__attribute_{self.attr_engine.id}": self.custom_vals.id,
+            f"__custom_{self.attr_engine.id}": "#FERDFGR",
+            f"__attribute_{self.attr_color.id}": self.value_red.id,
         }
         product_config_wizard_2.read(multi_vals)
 

--- a/product_configurator/tests/test_wizard.py
+++ b/product_configurator/tests/test_wizard.py
@@ -304,11 +304,11 @@ class ConfigurationWizard(ProductConfiguratorTestCases):
         )
         product_config_wizard_1.action_next_step()
         product_config_wizard_1.action_next_step()
-        product_config_wizard_1.write(
-            {
-                f"__attribute_{self.attr_model_line.id}": self.value_model_sport_line.id,
-            }
-        )
+
+        vals = {
+            f"__attribute_{self.attr_model_line.id}": self.value_model_sport_line.id,
+        }
+        product_config_wizard_1.write(vals)
         product_config_wizard_1.action_next_step()
         product_config_wizard_1.write(
             {
@@ -375,11 +375,10 @@ class ConfigurationWizard(ProductConfiguratorTestCases):
         )
         product_config_wizard_1.action_next_step()
         product_config_wizard_1.action_next_step()
-        product_config_wizard_1.write(
-            {
-                f"__attribute_{self.attr_model_line.id}": self.value_model_sport_line.id,
-            }
-        )
+        vals = {
+            f"__attribute_{self.attr_model_line.id}": self.value_model_sport_line.id,
+        }
+        product_config_wizard_1.write(vals)
         product_config_wizard_1.action_next_step()
         product_config_wizard_1.write(
             {


### PR DESCRIPTION
Applying changes using pre-commit settings from v17 to align as much as
possible v16 and avoid conflicts in fwd/bkp :)

I started by cherry-picking linting-only related changes from https://github.com/OCA/product-configurator/pull/117 (@dreispt I did some magic to preserve your commit, I've just renamed it).

On top of that I added some more changes to make v17 linting happy and then ported to v16 and making its linting happy too.

In this way we should have less conflicts when fwd/bkp changes as v16 seems quite active now.

There are several changes on v17 that will be probably nice to port here and w/o this change it will be a hell.

Has been an hard work, but sounds good now :sweat_smile: 

EDIT: I also restored the tests that were abandoned since v13 w/o fixing them all. At least we have a little bit more of test coverage.