### PR TITLE
[FIX] product_configurator_sale: Allow user to configure sale products

### DIFF
--- a/product_configurator_sale/__manifest__.py
+++ b/product_configurator_sale/__manifest__.py
@@ -8,7 +8,12 @@
     "author": "Pledra, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "website": "https://github.com/OCA/product-configurator",
-    "depends": ["sale_management", "product_configurator", "stock"],
+    "depends": [
+        "onchange_helper",
+        "product_configurator",
+        "sale_management",
+        "stock",
+    ],
     "data": [
         "security/ir.model.access.csv",
         "data/menu_product.xml",

--- a/product_configurator_sale/security/ir.model.access.csv
+++ b/product_configurator_sale/security/ir.model.access.csv
@@ -1,3 +1,4 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_product_configurator_sale,product_configurator_sale,model_product_configurator_sale,base.group_user,1,0,0,0
+access_product_configurator_sale_user,Product Configurator User for Product Configurator Sale wizard,model_product_configurator_sale,product_configurator.group_product_configurator,1,1,1,0
 access_product_configurator_sale_manager,product_configurator_sale,model_product_configurator_sale,product_configurator.group_product_configurator_manager,1,1,1,1

--- a/product_configurator_sale/tests/test_sale_order_line.py
+++ b/product_configurator_sale/tests/test_sale_order_line.py
@@ -1,8 +1,9 @@
 #  Copyright 2024 Simone Rubino - Aion Tech
 #  License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from odoo import Command
 from odoo.fields import first
-from odoo.tests import Form
+from odoo.tests import Form, new_test_user
 
 from odoo.addons.base.tests.common import BaseCommon
 
@@ -11,6 +12,24 @@ class TestSaleOrderLine(BaseCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.configurator_manager_group_xmlid = (
+            "product_configurator.group_product_configurator_manager"
+        )
+        cls.configurator_user_group_xmlid = (
+            "product_configurator.group_product_configurator"
+        )
+        cls.sale_user_group_xmlid = "sales_team.group_sale_salesman"
+        cls.configurator_user = new_test_user(
+            cls.env,
+            login="sale configurator user",
+            groups=",".join(
+                [
+                    cls.configurator_user_group_xmlid,
+                    cls.sale_user_group_xmlid,
+                ]
+            ),
+        )
+
         cls.customer = cls.env["res.partner"].create(
             {
                 "name": "Test partner",
@@ -118,3 +137,80 @@ class TestSaleOrderLine(BaseCommon):
         # Changing the configuration session changes the unit price
         order_line_20.config_session_id = config_session_10
         self.assertEqual(config_session_10.price, order_line_20.price_unit)
+
+    def test_user_access(self):
+        """A configurator and sale user
+        can configure and add products to sale orders."""
+        # Arrange
+        configurator_user = self.configurator_user
+        product_template = self.product_template
+        ptavs = product_template.attribute_line_ids.product_template_value_ids
+        ptav_10 = first(ptavs)
+        attribute = ptav_10.attribute_id
+
+        with self.with_user(configurator_user.login):
+            sale_order = self.env["sale.order"].create(
+                {
+                    "partner_id": self.customer.id,
+                }
+            )
+            # pre-condition
+            self.assertFalse(sale_order.order_line)
+            self.assertFalse(
+                self.env.user.has_group(self.configurator_manager_group_xmlid)
+            )
+            self.assertTrue(self.env.user.has_group(self.configurator_user_group_xmlid))
+            self.assertTrue(self.env.user.has_group(self.sale_user_group_xmlid))
+
+            # Act
+            self._configure_product(
+                sale_order,
+                product_template,
+                {
+                    attribute: ptav_10,
+                },
+            )
+
+        # Assert
+        self.assertTrue(sale_order.order_line)
+
+    def test_pricelist_discount_currency(self):
+        """
+        If the pricelist has a discount,
+        the currency of new lines is picked up from the pricelist."""
+        # Arrange
+        product_template = self.product_template
+        ptavs = product_template.attribute_line_ids.product_template_value_ids
+        ptav = first(ptavs)
+        attribute = ptav.attribute_id
+
+        pricelist = self.env.ref("product.list0")
+        pricelist.discount_policy = "without_discount"
+        pricelist.item_ids = [
+            Command.create(
+                {
+                    "applied_on": "1_product",
+                    "product_tmpl_id": product_template.id,
+                }
+            )
+        ]
+
+        sale_order = self.sale_order
+        sale_order.pricelist_id = pricelist
+        # pre-condition
+        self.assertTrue(pricelist._get_product_rule(product_template, 1))
+        self.assertTrue(pricelist.discount_policy, "without_discount")
+        self.assertEqual(sale_order.currency_id, pricelist.currency_id)
+
+        # Act
+        self._configure_product(
+            sale_order,
+            product_template,
+            {
+                attribute: ptav,
+            },
+        )
+
+        # Assert
+        order_line = sale_order.order_line
+        self.assertEqual(order_line.currency_id, pricelist.currency_id)

--- a/product_configurator_sale/wizard/product_configurator.py
+++ b/product_configurator_sale/wizard/product_configurator.py
@@ -34,14 +34,9 @@ class ProductConfiguratorSale(models.TransientModel):
         model_name = "sale.order.line"
         line_vals = self._get_order_line_vals(res["res_id"])
 
-        # Call onchange explicite as write and create
+        # Call onchange explicitly as write and create
         # will not trigger onchange automatically
-        order_line_obj = self.env[model_name]
-        cfg_session = self.config_session_id
-        specs = cfg_session.get_onchange_specifications(model=model_name)
-        updates = order_line_obj.onchange(line_vals, ["product_id"], specs)
-        values = updates.get("value", {})
-        values = cfg_session.get_vals_to_write(values=values, model=model_name)
+        values = self.env[model_name].play_onchanges(line_vals, ["product_id"])
         values.update(line_vals)
 
         if self.order_line_id:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,2 @@
+# https://github.com/OCA/server-tools/pull/3152
+odoo-addon-onchange_helper @ git+https://github.com/OCA/server-tools.git@refs/pull/3152/head#subdirectory=setup/onchange_helper


### PR DESCRIPTION
**Steps**
1. Create a user that has only the groups
    - Product Configurator / User
    - Sales / User: Own Documents Only

    ![image](https://github.com/user-attachments/assets/c9d5d898-0a41-4a06-939d-7b5c164a507c)

2. Log in with the created user
3. Create a sale order
4. Click on Configure Product
5. Complete the configuration wizard

**Observed**
The first time the wizard is saved (first click on Next button), the following error is raised:

>You are not allowed to create 'Product Configurator Sale' (product.configurator.sale) records.
>
>This operation is allowed for the following groups:
>	- Product Configurator/Manager
>
>Contact your administrator to request access if necessary.

**Expected**
Have the configured product in the sale order line

Depends on:
- [ ] https://github.com/OCA/server-tools/pull/3152