### PR TITLE
[FIX] [17.0] website_product_configurator : Add To Cart Disable bug

### DIFF
--- a/website_product_configurator/models/__init__.py
+++ b/website_product_configurator/models/__init__.py
@@ -1,3 +1,4 @@
 from . import product_config
 from . import res_config_settings
 from . import sale_order
+from . import product_template

--- a/website_product_configurator/models/product_template.py
+++ b/website_product_configurator/models/product_template.py
@@ -1,0 +1,27 @@
+from odoo import models
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    def _is_combination_possible(
+        self, combination, parent_combination=None, ignore_no_variant=False
+    ):
+        """Inherited the method to enhance combination validation for configurable
+        products (config_ok) and ensured the 'Add to Cart' button functions correctly
+        after selecting multiple options."""
+
+        self.ensure_one()
+        # Check if the default method restricts the combination, but the product is
+        # configurable.
+        if (
+            not self._is_combination_possible_by_config(combination, ignore_no_variant)
+            and self.config_ok
+        ):
+            return True
+
+        return super()._is_combination_possible(
+            combination,
+            parent_combination=parent_combination,
+            ignore_no_variant=ignore_no_variant,
+        )


### PR DESCRIPTION
When configuring the product and selecting multiple options, the 'Add to Cart' button is being disabled at the website level. Fixing it in case of the config_ok products as we really do not need to find combination based on Odoo logic.

![Cart_Button_Disabled](https://github.com/user-attachments/assets/457a8767-2fe9-4724-88fe-61742afaeb05)
