### PR TITLE
[FIX] product_configurator: avoid overriding compute

### DIFF
--- a/product_configurator/models/product.py
+++ b/product_configurator/models/product.py
@@ -456,7 +456,7 @@ class ProductProduct(models.Model):
                 product.mapped("product_template_attribute_value_ids.weight_extra")
             )
 
-    def _compute_product_weight(self):
+    def _compute_weight(self):
         for product in self:
             if product.config_ok:
                 tmpl_weight = product.product_tmpl_id.weight
@@ -464,10 +464,10 @@ class ProductProduct(models.Model):
             else:
                 product.weight = product.weight_dummy
 
-    def _search_product_weight(self, operator, value):
+    def _search_weight(self, operator, value):
         return [("weight_dummy", operator, value)]
 
-    def _inverse_product_weight(self):
+    def _inverse_weight(self):
         """Store weight in dummy field"""
         self.weight_dummy = self.weight
 
@@ -477,9 +477,9 @@ class ProductProduct(models.Model):
     weight_extra = fields.Float(compute="_compute_product_weight_extra")
     weight_dummy = fields.Float(string="Manual Weight", digits="Stock Weight")
     weight = fields.Float(
-        compute="_compute_product_weight",
-        inverse="_inverse_product_weight",
-        search="_search_product_weight",
+        compute="_compute_weight",
+        inverse="_inverse_weight",
+        search="_search_weight",
         store=False,
     )
 

--- a/product_configurator/tests/test_product.py
+++ b/product_configurator/tests/test_product.py
@@ -284,25 +284,25 @@ class TestProduct(ProductConfiguratorTestCases):
             Method: _get_mako_tmpl_name()",
         )
 
-    def test_08_compute_product_weight(self):
+    def test_08_compute_weight(self):
         product_product = self._get_product_id()
         self.config_product.weight = 10
         product_product.weight_extra = 20
-        product_product._compute_product_weight()
+        product_product._compute_weight()
         self.assertEqual(
             product_product.weight,
             30,
             "Error: If value are not get 30\
-            Method: _compute_product_weight()",
+            Method: _compute_weight()",
         )
         product_product.config_ok = False
         product_product.weight_dummy = 50
-        product_product._compute_product_weight()
+        product_product._compute_weight()
         self.assertEqual(
             product_product.weight,
             50,
             "Error: If value are not get 50\
-            Method: _compute_product_weight()",
+            Method: _compute_weight()",
         )
 
     def test_09_compute_config_name(self):
@@ -671,15 +671,15 @@ class TestProduct(ProductConfiguratorTestCases):
             Method: _get_config_name()",
         )
 
-    def test_21_search_product_weight(self):
+    def test_21_search_weight(self):
         product_product = self._get_product_id()
         operator = "and"
         value = 10
-        search_product_weight = product_product._search_product_weight(operator, value)
+        search_weight = product_product._search_weight(operator, value)
         self.assertTrue(
-            search_product_weight,
+            search_weight,
             "Error: If value False\
-            Method: _search_product_weight()",
+            Method: _search_weight()",
         )
 
     def test_22_search_weight(self):


### PR DESCRIPTION
The module [product_logistics_uom](https://github.com/OCA/product-attribute/blob/f417c5799b648c936e522d8e994005e6972fb947/product_logistics_uom/models/product_product.py#L27) already defines  `_compute_product_weight` and `_inverse_product_weight` but for a different field. Since this field is called `weight` and not `product_weight`  I think the best way to ensure that every compute/inverse is triggered is by changing the name here