### PR TITLE
[18.0][FIX] product_configurator: hide disallowed custom option in wizard

### DIFF
--- a/product_configurator/models/product_config.py
+++ b/product_configurator/models/product_config.py
@@ -1608,6 +1608,13 @@ class ProductConfigSession(models.Model):
             values[key] = new_lst
         return values
 
+    def _get_line_available_vals(self, attr_line, domains):
+        """Return available value ids for the attribute line field domain."""
+        field_prefix = self.env["product.configurator"]._prefixes.get("field_prefix")
+        field_name = f"{field_prefix}{attr_line.attribute_id.id}"
+        domain = domains.get(field_name, [("id", "in", [])])
+        return domain[0][2] if domain and len(domain[0]) >= 3 else []
+
 
 class ProductConfigSessionCustomValue(models.Model):
     _name = "product.config.session.custom.value"

--- a/product_configurator/wizard/product_configurator.py
+++ b/product_configurator/wizard/product_configurator.py
@@ -638,7 +638,7 @@ class ProductConfigurator(models.TransientModel):
         except Exception as exc:
             raise UserError(
                 self.env._(
-                    "There was a problem rendering the view " "(dynamic_form not found)"
+                    "There was a problem rendering the view (dynamic_form not found)"
                 )
             ) from exc
 
@@ -820,9 +820,16 @@ class ProductConfigurator(models.TransientModel):
                 check_val_ids=attr_line.value_ids.ids,
                 product_template_attribute_line_id=attr_line.id,
             )
-            if attr_line.custom:
-                config_session_obj = self.env["product.config.session"]
-                custom_val = config_session_obj.get_custom_value_id()
+            domains = self.get_onchange_domains(
+                cfg_val_ids=attr_line.value_ids.ids,
+                product_tmpl_id=self.product_tmpl_id,
+                config_session_id=self.config_session_id,
+            )
+            available_vals = self.config_session_id._get_line_available_vals(
+                attr_line, domains
+            )
+            custom_val = self.config_session_id.get_custom_value_id()
+            if attr_line.custom and custom_val.id in available_vals:
                 available_value_ids.append(custom_val.id)
             # Handle default values for dynamic fields on Odoo frontend
             res[0].update(


### PR DESCRIPTION
**Changed:**

- Update the function read to prevent always adding Custom option for attribute lines that allows custom values. Should respect the available values for the attribute line.


**Reproduce:**
1/ 

<img width="1252" height="863" alt="image" src="https://github.com/user-attachments/assets/eb9ba0f4-24d4-40bc-85ad-e89edb5f7bfb" />

2/ Setup restriction

<img width="1230" height="775" alt="image" src="https://github.com/user-attachments/assets/cb3feb26-db8b-4422-99c2-5c749aaccadf" />


<img width="1920" height="346" alt="image" src="https://github.com/user-attachments/assets/88734564-a3ca-400a-87f2-ea6fd9deaf2c" />


3/ Config product

<img width="1531" height="853" alt="image" src="https://github.com/user-attachments/assets/e3e5cbd7-ee80-437a-9bd2-ee7389ebefa4" />

Before clicking on the Transmission

<img width="1480" height="1035" alt="image" src="https://github.com/user-attachments/assets/19396e09-3513-4da1-97c9-1331c5fdc9af" />

After clicking on the Transmission -> The option Custom disappears because the domain is recomputed.

<img width="1534" height="1023" alt="image" src="https://github.com/user-attachments/assets/92067cbb-86b0-4167-8744-885ed7817b97" />


