### PR TITLE
[18.0][FIX] product_configurator_sale: permssion requires Administrator

### DIFF
--- a/product_configurator_mrp/models/product_config.py
+++ b/product_configurator_mrp/models/product_config.py
@@ -150,5 +150,7 @@ class ProductConfigSession(models.Model):
         variant = super().create_get_variant(
             value_ids=value_ids, custom_vals=custom_vals
         )
-        self.create_get_bom(variant=variant, product_tmpl_id=self.product_tmpl_id)
+        self.sudo().create_get_bom(
+            variant=variant, product_tmpl_id=self.product_tmpl_id
+        )
         return variant

--- a/product_configurator_mrp/wizard/product_configurator_mrp.py
+++ b/product_configurator_mrp/wizard/product_configurator_mrp.py
@@ -16,7 +16,7 @@ class ProductConfiguratorMrp(models.TransientModel):
     )
 
     def get_mrp_production_action(self):
-        mrp_action = self.env.ref("mrp.mrp_production_action").read()
+        mrp_action = self.env.ref("mrp.mrp_production_action").sudo().read()
         if mrp_action:
             mrp_action = mrp_action[0]
             context = safe_eval(

--- a/product_configurator_sale/models/__init__.py
+++ b/product_configurator_sale/models/__init__.py
@@ -1,4 +1,4 @@
 # Copyright (C) 2021 Open Source Integrators
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from . import sale
+from . import product_config_session, sale

--- a/product_configurator_sale/models/product_config_session.py
+++ b/product_configurator_sale/models/product_config_session.py
@@ -1,0 +1,10 @@
+from odoo import models
+
+
+class ProductConfigSession(models.Model):
+    _inherit = "product.config.session"
+
+    def create_get_variant(self, value_ids=None, custom_vals=None):
+        return super(ProductConfigSession, self.sudo()).create_get_variant(
+            value_ids=value_ids, custom_vals=custom_vals
+        )


### PR DESCRIPTION
The configuration of products caused a permission issue when being executed by Sales or Manufacturing users. Without this fix product configuration was only possible for Administrators.